### PR TITLE
Boletim Informativo: editor de blocos, publicação e página pública (US-16/18/19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ SEED_ADMIN_PASSWORD=troque-no-primeiro-acesso
 COOKIE_SECURE=false
 # Base URL usada no link de redefinição de senha enviado por e-mail.
 APP_BASE_URL=http://localhost:5173
+# URL pública absoluta do site, usada nas meta tags Open Graph do boletim (og:url/og:image).
+# Injetada server-side apenas em produção. Ex.: https://www.adventistastucuruvi.com.br
+PUBLIC_BASE_URL=
 
 # --- Recuperação de senha ---
 PASSWORD_RESET_TTL_MIN=30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ Modelo híbrido (SPA com React Router + páginas dedicadas):
 
 Cada clube/departamento com página própria (Desbravadores, futuros Aventureiros etc.) segue uma receita padronizada: estrutura fixa de 5 seções (Hero, Sobre, Quem pode participar, Galeria em carrossel, Fale conosco), paleta própria no Tailwind, header trocando de cor via `useLocation`. Receita completa em `docs/patterns/pagina-departamento.md` — consultar antes de criar nova página de departamento.
 
+### Boletim Informativo (US-16/17/18/19)
+
+Artigo semanal compartilhado no WhatsApp. Editado no painel (`/painel/boletins` + editor `/painel/boletins/:id`, perm `boletim:write`), publicado por slug (perm `boletim:publish`) e servido na rota pública `/boletins/:slug` (full width, fundo padronizado; 404 para rascunho). Conteúdo é **JSONB em linhas → colunas → blocos** (Título, Texto rico/TipTap, Imagem, Galeria, Vídeo do YouTube), com drag-and-drop (dnd-kit) entre colunas/linhas; imagens vêm da biblioteca de mídia (US-17). O **renderer compartilhado** `src/components/boletim/BulletinRenderer` é usado tanto pela página pública quanto pela pré-visualização do editor (`/painel/boletins/:id/preview`). **Open Graph injetado server-side só em produção** (Express edita o `dist/index.html`; em dev sob o Vite não injeta), compondo `og:url`/`og:image` a partir da env **`PUBLIC_BASE_URL`** (URL pública absoluta do site).
+
 ### Seções da Página Principal
 
 1. **Hero** — fundo azul escuro com foto da igreja (10% opacidade), título "Adventistas Tucuruvi", versículo (text-blue-300), countdown pro próximo culto (glass card), CTA "Assista ao Vivo"

--- a/deploy.sh
+++ b/deploy.sh
@@ -61,6 +61,9 @@ if [ ! -f "$ENV_FILE" ]; then
   read -rp "Porta da aplicação [3001]: " app_port
   app_port="${app_port:-3001}"
 
+  read -rp "URL pública do site (para o preview do boletim no WhatsApp/Open Graph) [https://www.adventistastucuruvi.com.br]: " public_base_url
+  public_base_url="${public_base_url:-https://www.adventistastucuruvi.com.br}"
+
   echo ""
   echo "--- Banco de dados (Postgres) ---"
   read -rp "Usuário do Postgres [iasd]: " pg_user
@@ -89,6 +92,10 @@ SMTP_PORT=$smtp_port
 SMTP_FROM=$smtp_from
 SMTP_TO=$smtp_to
 PORT=$app_port
+
+# --- App / Open Graph ---
+# URL pública absoluta do site, usada nas meta tags do boletim (og:url/og:image).
+PUBLIC_BASE_URL=$public_base_url
 
 # --- Banco de dados (Postgres) ---
 POSTGRES_USER=$pg_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - .env.local
     environment:
       - UPLOADS_DIR=/app/uploads
+      # URL pública absoluta do site, para as meta tags Open Graph do boletim.
+      # Lida de .env.local; redeclarada aqui para deixar explícita.
+      - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-}
     volumes:
       - uploads:/app/uploads
     depends_on:

--- a/docs/historias/README.md
+++ b/docs/historias/README.md
@@ -48,10 +48,10 @@ cookies/DTO/requireAuth · `7a2167c` transações · telas `7ad1775`/`1b36e9a`).
 | **Interface do Painel** | [US-13](US-13-menu-lateral.md) | Menu lateral colapsável do painel | ✅ | `77a69cb`, `2509a18`, `f30cc4a`, `90307d5`, `a0547f3` |
 | | [US-14](US-14-configuracoes-email.md) | Tela de configurações (e-mail do sistema) | ✅ | `bc67dda`, `b043b78`, `85e8573`, `fa6ff42`, `38124ad` |
 | **Segurança (transversal)** | [US-15](US-15-criptografia-segredos.md) | Criptografia de segredos de configuração | ✅ | `7ca3764`, `c2143d3`, `9f50003` |
-| **Boletim Informativo** | [US-16](US-16-editor-boletim.md) | Editor de boletim (blocos) | ✅ | `feat/boletim` |
-| | [US-17](US-17-biblioteca-midia.md) | Biblioteca de mídia (upload e reuso de imagens) | ✅ | `0b84be9`, `9abd119`, `147f6ee`, `52e88ed`, `dc54f0d` |
-| | [US-18](US-18-publicar-gerar-link.md) | Publicar boletim e gerar link | ✅ | `feat/boletim` |
-| | [US-19](US-19-pagina-publica-preview.md) | Página pública do boletim + preview no WhatsApp | ✅ | `feat/boletim` |
+| **Boletim Informativo** | [US-16](US-16-editor-boletim.md) | Editor de boletim (blocos) | ✅ | `1752a0a`, `7111bd6`, `f34f7da`, `34551eb`, `eb38363` |
+| | [US-17](US-17-biblioteca-midia.md) | Biblioteca de mídia (upload e reuso de imagens) | ✅ | `0b84be9`, `9abd119`, `147f6ee`, `52e88ed`, `dc54f0d`, `08aa088`, `c36df2a`, `ffb64c1` |
+| | [US-18](US-18-publicar-gerar-link.md) | Publicar boletim e gerar link | ✅ | `a8b2498`, `033bb1c`, `ffb64c1` |
+| | [US-19](US-19-pagina-publica-preview.md) | Página pública do boletim + preview no WhatsApp | ✅ | `46938be`, `3712b45`, `d54a74f`, `b574245` |
 | | [US-20](US-20-gerenciar-boletins.md) | Listar e gerenciar boletins | ⏳ | — |
 | | [US-21](US-21-templates-boletim.md) | Templates de boletim | ⏳ | — |
 | **Redirecionamento de Links** | [US-22](US-22-redirecionamento-links.md) | Encurtador/redirecionador de links próprio | ⏳ | — |

--- a/docs/historias/README.md
+++ b/docs/historias/README.md
@@ -23,6 +23,8 @@ hierarquia de erros, `requireAuth`, CSRF) e as telas mínimas de auth (login, es
 - **Plano:** [`docs/superpowers/plans/2026-06-15-autenticacao.md`](../superpowers/plans/2026-06-15-autenticacao.md)
 - **Fora deste épico (specs próprias):** RBAC granular (US-10/11), convites (US-06/07), painel/configurações (US-13/14) e demais.
 
+**Épico do Boletim — editor/publicação/página pública ENTREGUE** ✅ (branch `feat/boletim`). Fecha US-16, US-18 e US-19 (e os CA-04/CA-05 pendentes da US-17). Spec: [`docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md`](../superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md) · Plano: [`docs/superpowers/plans/2026-06-16-boletim.md`](../superpowers/plans/2026-06-16-boletim.md).
+
 Legenda: ✅ Entregue · ⏳ Pendente. A coluna *Commits* aponta os commits principais de cada história
 (commits de fundação que as sustentam: `6f5de4f` deps · `2bfe5ca` config · `e231e8f` erros · `77db8ac`
 schema · `823a962` Password · `196b760` TokenService · `f726a39` CSRF · `625a526` repos · `8efd5cc`
@@ -46,10 +48,10 @@ cookies/DTO/requireAuth · `7a2167c` transações · telas `7ad1775`/`1b36e9a`).
 | **Interface do Painel** | [US-13](US-13-menu-lateral.md) | Menu lateral colapsável do painel | ✅ | `77a69cb`, `2509a18`, `f30cc4a`, `90307d5`, `a0547f3` |
 | | [US-14](US-14-configuracoes-email.md) | Tela de configurações (e-mail do sistema) | ✅ | `bc67dda`, `b043b78`, `85e8573`, `fa6ff42`, `38124ad` |
 | **Segurança (transversal)** | [US-15](US-15-criptografia-segredos.md) | Criptografia de segredos de configuração | ✅ | `7ca3764`, `c2143d3`, `9f50003` |
-| **Boletim Informativo** | [US-16](US-16-editor-boletim.md) | Editor de boletim (blocos) | ⏳ | — |
+| **Boletim Informativo** | [US-16](US-16-editor-boletim.md) | Editor de boletim (blocos) | ✅ | `feat/boletim` |
 | | [US-17](US-17-biblioteca-midia.md) | Biblioteca de mídia (upload e reuso de imagens) | ✅ | `0b84be9`, `9abd119`, `147f6ee`, `52e88ed`, `dc54f0d` |
-| | [US-18](US-18-publicar-gerar-link.md) | Publicar boletim e gerar link | ⏳ | — |
-| | [US-19](US-19-pagina-publica-preview.md) | Página pública do boletim + preview no WhatsApp | ⏳ | — |
+| | [US-18](US-18-publicar-gerar-link.md) | Publicar boletim e gerar link | ✅ | `feat/boletim` |
+| | [US-19](US-19-pagina-publica-preview.md) | Página pública do boletim + preview no WhatsApp | ✅ | `feat/boletim` |
 | | [US-20](US-20-gerenciar-boletins.md) | Listar e gerenciar boletins | ⏳ | — |
 | | [US-21](US-21-templates-boletim.md) | Templates de boletim | ⏳ | — |
 | **Redirecionamento de Links** | [US-22](US-22-redirecionamento-links.md) | Encurtador/redirecionador de links próprio | ⏳ | — |

--- a/docs/historias/US-16-editor-boletim.md
+++ b/docs/historias/US-16-editor-boletim.md
@@ -79,8 +79,12 @@ O Boletim é o artigo semanal compartilhado no grupo de WhatsApp. O conteúdo é
 - **US-18** (publicação) consome o conteúdo salvo aqui.
 
 ## Definição de pronto
-- [ ] Adicionar, editar, reordenar e remover blocos (Título, Texto, Imagem, Galeria, Vídeo).
-- [ ] Galeria com múltiplas imagens em grade responsiva; Vídeo do YouTube incorporado.
-- [ ] Resumo e imagem de capa salvos.
-- [ ] Conteúdo persistido como JSON e recuperável para reedição.
-- [ ] Permissão `bulletins:write` exigida.
+- [x] Adicionar, editar, reordenar e remover blocos (Título, Texto, Imagem, Galeria, Vídeo).
+- [x] Galeria com múltiplas imagens em grade responsiva; Vídeo do YouTube incorporado.
+- [x] Resumo e imagem de capa salvos.
+- [x] Conteúdo persistido como JSON e recuperável para reedição.
+- [x] Permissão `boletim:write` exigida.
+
+> **Nota de implementação:** o modelo de conteúdo evoluiu além da lista plana do spec original para uma estrutura **linhas → colunas → blocos** (cada linha tem 1–4 colunas; cada coluna empilha blocos), com drag-and-drop multi-container (dnd-kit) entre quaisquer colunas/linhas + fallback de botões. O bloco de Texto (TipTap) ganhou um seletor de estilo **Parágrafo / Título 1 / 2 / 3** além da formatação básica.
+
+> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-16-editor-boletim.md
+++ b/docs/historias/US-16-editor-boletim.md
@@ -2,6 +2,8 @@
 
 **Épico:** Boletim Informativo · **Prioridade:** Must · **Estimativa:** 8 pts
 
+> ✅ **Entregue** em `1752a0a`, `7111bd6`, `f34f7da`, `34551eb`, `eb38363` — branch `feat/boletim`. Ver [spec](../superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md) e [plano](../superpowers/plans/2026-06-16-boletim.md).
+
 ## História
 
 > **Como** Administrador,
@@ -79,12 +81,10 @@ O Boletim é o artigo semanal compartilhado no grupo de WhatsApp. O conteúdo é
 - **US-18** (publicação) consome o conteúdo salvo aqui.
 
 ## Definição de pronto
-- [x] Adicionar, editar, reordenar e remover blocos (Título, Texto, Imagem, Galeria, Vídeo).
-- [x] Galeria com múltiplas imagens em grade responsiva; Vídeo do YouTube incorporado.
-- [x] Resumo e imagem de capa salvos.
-- [x] Conteúdo persistido como JSON e recuperável para reedição.
-- [x] Permissão `boletim:write` exigida.
+- [ ] Adicionar, editar, reordenar e remover blocos (Título, Texto, Imagem, Galeria, Vídeo).
+- [ ] Galeria com múltiplas imagens em grade responsiva; Vídeo do YouTube incorporado.
+- [ ] Resumo e imagem de capa salvos.
+- [ ] Conteúdo persistido como JSON e recuperável para reedição.
+- [ ] Permissão `boletim:write` exigida.
 
 > **Nota de implementação:** o modelo de conteúdo evoluiu além da lista plana do spec original para uma estrutura **linhas → colunas → blocos** (cada linha tem 1–4 colunas; cada coluna empilha blocos), com drag-and-drop multi-container (dnd-kit) entre quaisquer colunas/linhas + fallback de botões. O bloco de Texto (TipTap) ganhou um seletor de estilo **Parágrafo / Título 1 / 2 / 3** além da formatação básica.
-
-> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-17-biblioteca-midia.md
+++ b/docs/historias/US-17-biblioteca-midia.md
@@ -2,6 +2,8 @@
 
 **Épico:** Boletim Informativo · **Prioridade:** Must · **Estimativa:** 8 pts
 
+> ✅ **Entregue** em `0b84be9`, `9abd119`, `147f6ee`, `52e88ed`, `dc54f0d` — branch `feat/biblioteca-midia`; CA-04/CA-05 em `08aa088`, `c36df2a`, `ffb64c1` — branch `feat/boletim`. Ver [spec](../superpowers/specs/2026-06-16-biblioteca-midia-design.md) e [plano](../superpowers/plans/2026-06-16-biblioteca-midia.md).
+
 ## História
 
 > **Como** Administrador,
@@ -54,16 +56,12 @@ A biblioteca é a fonte de imagens do editor de boletim (US-16), mas é pensada 
 - Consumida por **US-16** (bloco de Imagem) e **US-19** (capa do boletim).
 
 ## Definição de pronto
-- [x] Upload com validação de tipo/tamanho por conteúdo.
-- [x] Listagem em grade com busca por nome.
-- [x] Seleção de imagem existente a partir do editor. *(CA-04 — entregue com o editor (US-16): `MediaPicker` com abas "Biblioteca" e "Enviar" (upload no próprio modal); a imagem é inserida por referência (id).)*
-- [x] Remoção protegida quando a imagem está em uso. *(CA-05 — entregue: o editor registra um usage checker no `MediaService` que varre linhas → colunas → blocos + a imagem de capa; remoção de imagem em uso é bloqueada.)*
-- [x] Arquivos em volume + metadata no banco; permissão `media:manage` exigida.
+- [ ] Upload com validação de tipo/tamanho por conteúdo.
+- [ ] Listagem em grade com busca por nome.
+- [ ] Seleção de imagem existente a partir do editor. *(CA-04 — entregue com o editor (US-16): `MediaPicker` com abas "Biblioteca" e "Enviar" (upload no próprio modal); a imagem é inserida por referência (id).)*
+- [ ] Remoção protegida quando a imagem está em uso. *(CA-05 — entregue: o editor registra um usage checker no `MediaService` que varre linhas → colunas → blocos + a imagem de capa; remoção de imagem em uso é bloqueada.)*
+- [ ] Arquivos em volume + metadata no banco; permissão `media:manage` exigida.
 
 ### Extras de UX entregues (além dos CAs)
 - **Modal de detalhes da mídia:** botão "expandir" flutuante no card (visível no hover; em telas touch a miniatura é clicável) abre um modal em 2 colunas — preview maior à esquerda, e à direita os metadados (dimensões, tipo, tamanho, data de envio) + ações **Baixar** (download do original) e **Fechar**.
 - **Spinner de carregamento:** na grade durante o fetch (sem flash de estado vazio) e sobre a imagem do modal enquanto ela carrega. Componente `Spinner` adicionado ao kit; `Modal` ganhou prop `size` (`md`/`lg`/`xl`). Ver `docs/patterns/area-administrativa-visual.md`.
-
-> **Entregue** na branch `feat/biblioteca-midia` (sub-projeto 2/5 do épico do Boletim). Spec: `docs/superpowers/specs/2026-06-16-biblioteca-midia-design.md` · Plano: `docs/superpowers/plans/2026-06-16-biblioteca-midia.md`.
->
-> **CA-04 e CA-05 fechados** com o editor de boletim, na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-17-biblioteca-midia.md
+++ b/docs/historias/US-17-biblioteca-midia.md
@@ -56,12 +56,14 @@ A biblioteca é a fonte de imagens do editor de boletim (US-16), mas é pensada 
 ## Definição de pronto
 - [x] Upload com validação de tipo/tamanho por conteúdo.
 - [x] Listagem em grade com busca por nome.
-- [ ] Seleção de imagem existente a partir do editor. *(CA-04 — adiado para o sub-projeto do editor (US-16); o endpoint de listagem e a referência por id já estão prontos, falta o modal-picker.)*
-- [ ] Remoção protegida quando a imagem está em uso. *(CA-05 — adiado; o registry de usage checkers já existe (vazio) como gancho, e o editor pluga o checker quando boletins existirem.)*
+- [x] Seleção de imagem existente a partir do editor. *(CA-04 — entregue com o editor (US-16): `MediaPicker` com abas "Biblioteca" e "Enviar" (upload no próprio modal); a imagem é inserida por referência (id).)*
+- [x] Remoção protegida quando a imagem está em uso. *(CA-05 — entregue: o editor registra um usage checker no `MediaService` que varre linhas → colunas → blocos + a imagem de capa; remoção de imagem em uso é bloqueada.)*
 - [x] Arquivos em volume + metadata no banco; permissão `media:manage` exigida.
 
 ### Extras de UX entregues (além dos CAs)
 - **Modal de detalhes da mídia:** botão "expandir" flutuante no card (visível no hover; em telas touch a miniatura é clicável) abre um modal em 2 colunas — preview maior à esquerda, e à direita os metadados (dimensões, tipo, tamanho, data de envio) + ações **Baixar** (download do original) e **Fechar**.
 - **Spinner de carregamento:** na grade durante o fetch (sem flash de estado vazio) e sobre a imagem do modal enquanto ela carrega. Componente `Spinner` adicionado ao kit; `Modal` ganhou prop `size` (`md`/`lg`/`xl`). Ver `docs/patterns/area-administrativa-visual.md`.
 
-> **Entregue** na branch `feat/biblioteca-midia` (sub-projeto 2/5 do épico do Boletim). Spec: `docs/superpowers/specs/2026-06-16-biblioteca-midia-design.md` · Plano: `docs/superpowers/plans/2026-06-16-biblioteca-midia.md`. CA-04 e o bloqueio real de CA-05 saem com o editor (US-16).
+> **Entregue** na branch `feat/biblioteca-midia` (sub-projeto 2/5 do épico do Boletim). Spec: `docs/superpowers/specs/2026-06-16-biblioteca-midia-design.md` · Plano: `docs/superpowers/plans/2026-06-16-biblioteca-midia.md`.
+>
+> **CA-04 e CA-05 fechados** com o editor de boletim, na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-18-publicar-gerar-link.md
+++ b/docs/historias/US-18-publicar-gerar-link.md
@@ -55,7 +55,9 @@ Todo boletim nasce como **rascunho** (US-16). Publicar o torna acessível public
 - **US-16** (conteúdo) e **US-19** (página pública que o link aponta).
 
 ## Definição de pronto
-- [ ] Slug gerado do título, sem acentos/caracteres inválidos, único.
-- [ ] Publicar/despublicar com transição de estado e `published_at`.
-- [ ] Slug estável após publicado.
-- [ ] Publicação incompleta bloqueada; permissão `bulletins:publish` exigida.
+- [x] Slug gerado do título, sem acentos/caracteres inválidos, único.
+- [x] Publicar/despublicar com transição de estado e `published_at`.
+- [x] Slug estável após publicado.
+- [x] Publicação incompleta bloqueada; permissão `boletim:publish` exigida.
+
+> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-18-publicar-gerar-link.md
+++ b/docs/historias/US-18-publicar-gerar-link.md
@@ -2,6 +2,8 @@
 
 **Épico:** Boletim Informativo · **Prioridade:** Must · **Estimativa:** 5 pts
 
+> ✅ **Entregue** em `a8b2498`, `033bb1c`, `ffb64c1` — branch `feat/boletim`. Ver [spec](../superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md) e [plano](../superpowers/plans/2026-06-16-boletim.md).
+
 ## História
 
 > **Como** Administrador,
@@ -55,9 +57,7 @@ Todo boletim nasce como **rascunho** (US-16). Publicar o torna acessível public
 - **US-16** (conteúdo) e **US-19** (página pública que o link aponta).
 
 ## Definição de pronto
-- [x] Slug gerado do título, sem acentos/caracteres inválidos, único.
-- [x] Publicar/despublicar com transição de estado e `published_at`.
-- [x] Slug estável após publicado.
-- [x] Publicação incompleta bloqueada; permissão `boletim:publish` exigida.
-
-> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.
+- [ ] Slug gerado do título, sem acentos/caracteres inválidos, único.
+- [ ] Publicar/despublicar com transição de estado e `published_at`.
+- [ ] Slug estável após publicado.
+- [ ] Publicação incompleta bloqueada; permissão `boletim:publish` exigida.

--- a/docs/historias/US-19-pagina-publica-preview.md
+++ b/docs/historias/US-19-pagina-publica-preview.md
@@ -2,6 +2,8 @@
 
 **Épico:** Boletim Informativo · **Prioridade:** Must · **Estimativa:** 8 pts
 
+> ✅ **Entregue** em `46938be`, `3712b45`, `d54a74f`, `b574245` — branch `feat/boletim`. Ver [spec](../superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md) e [plano](../superpowers/plans/2026-06-16-boletim.md).
+
 ## História
 
 > **Como** membro da igreja que recebe o link no WhatsApp,
@@ -58,11 +60,9 @@ Esta história entrega o que o link da **US-18** abre: a página pública do bol
 - **US-18** (slug/estado publicado) e **US-16** (conteúdo/metadados).
 
 ## Definição de pronto
-- [x] Página pública renderizando os blocos, responsiva e on-brand.
-- [x] Meta tags Open Graph servidas no HTML inicial (validadas no preview do WhatsApp).
-- [x] Rascunhos/despublicados não acessíveis publicamente.
-- [x] Botão "Copiar link" com confirmação.
+- [ ] Página pública renderizando os blocos, responsiva e on-brand.
+- [ ] Meta tags Open Graph servidas no HTML inicial (validadas no preview do WhatsApp).
+- [ ] Rascunhos/despublicados não acessíveis publicamente.
+- [ ] Botão "Copiar link" com confirmação.
 
 > **Nota de implementação:** a injeção de Open Graph server-side roda **apenas em produção** (Express serve o `dist/index.html`; em dev sob o Vite não injeta) e compõe `og:url`/`og:image` a partir da env **`PUBLIC_BASE_URL`**. A página pública é **full width**, com **fundo padronizado** (padrão de pontos `.boletim-bg`). Há ainda "Compartilhar no WhatsApp" e **pré-visualização** em nova aba (`/painel/boletins/:id/preview`).
-
-> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/historias/US-19-pagina-publica-preview.md
+++ b/docs/historias/US-19-pagina-publica-preview.md
@@ -58,7 +58,11 @@ Esta história entrega o que o link da **US-18** abre: a página pública do bol
 - **US-18** (slug/estado publicado) e **US-16** (conteúdo/metadados).
 
 ## Definição de pronto
-- [ ] Página pública renderizando os blocos, responsiva e on-brand.
-- [ ] Meta tags Open Graph servidas no HTML inicial (validadas no preview do WhatsApp).
-- [ ] Rascunhos/despublicados não acessíveis publicamente.
-- [ ] Botão "Copiar link" com confirmação.
+- [x] Página pública renderizando os blocos, responsiva e on-brand.
+- [x] Meta tags Open Graph servidas no HTML inicial (validadas no preview do WhatsApp).
+- [x] Rascunhos/despublicados não acessíveis publicamente.
+- [x] Botão "Copiar link" com confirmação.
+
+> **Nota de implementação:** a injeção de Open Graph server-side roda **apenas em produção** (Express serve o `dist/index.html`; em dev sob o Vite não injeta) e compõe `og:url`/`og:image` a partir da env **`PUBLIC_BASE_URL`**. A página pública é **full width**, com **fundo padronizado** (padrão de pontos `.boletim-bg`). Há ainda "Compartilhar no WhatsApp" e **pré-visualização** em nova aba (`/painel/boletins/:id/preview`).
+
+> **Entregue** na branch `feat/boletim`. Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

--- a/docs/superpowers/plans/2026-06-16-boletim.md
+++ b/docs/superpowers/plans/2026-06-16-boletim.md
@@ -1,0 +1,985 @@
+# Boletim (editor + publicação + página pública) — Plano de Implementação
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Entregar o ciclo completo do Boletim Informativo: editor de blocos (US-16), publicação com link estável (US-18) e página pública com preview de WhatsApp (US-19) — fechando também CA-04/CA-05 da US-17.
+
+**Architecture:** Backend em camadas (`routes → controller → service → repository → db`) num módulo `server/modules/boletins/`, conteúdo persistido como JSONB. Frontend React com um `BulletinRenderer` **compartilhado** entre a pré-visualização do editor e a página pública. Open Graph injetado server-side no `dist/index.html` (produção). Mídia reaproveitada via picker + usage checker registrado no `MediaService`.
+
+**Tech Stack:** Express 5 + PostgreSQL 16 (JSONB) · React 18 + TS + Vite · TipTap (texto rico) · @dnd-kit (reordenar) · Zod (schemas client+server). Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md`.
+
+**Convenção de verificação (este projeto NÃO tem testes automatizados):** cada tarefa termina com `npm run build` (typecheck Vite + `tsc -p tsconfig.server.json`) passando, e — quando há comportamento — verificação manual via `docker compose up --build` ou `npm run dev`+`npm run dev:server`. Substitui o passo de "rodar teste" da TDD. Commits frequentes.
+
+**Lembretes de convenção do projeto:**
+- ESM no backend: imports internos em `server/` usam sufixo `.js` mesmo em `.ts`.
+- Schemas Zod duplicados: fonte em `server/`, espelho em `src/schemas/` — manter em sincronia.
+- Frontend usa path alias `@/*` → `src/*` e **exclusivamente** o kit de UI `src/painel/ui/`.
+- Listagens paginadas: contrato `?page=&limit=` + envelope `{ data, pagination }` via `core/pagination.ts`.
+
+---
+
+## Fase 0 — Dependências
+
+### Task 0: Instalar dependências novas
+
+**Files:**
+- Modify: `package.json` (via npm)
+
+- [ ] **Step 1: Instalar libs do editor de texto e drag-and-drop**
+
+```bash
+npm install @tiptap/react @tiptap/pm @tiptap/starter-kit @tiptap/extension-link @tiptap/html @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+Nota: `@tiptap/pm` é peer-dep do TipTap; `@tiptap/html` faz `generateHTML` para o renderer. Backend não precisa de libs novas.
+
+- [ ] **Step 2: Verificar build limpo**
+
+Run: `npm run build`
+Expected: build do Vite e `tsc` do server passam (ainda sem uso das libs, só instaladas).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(boletim): adiciona TipTap e dnd-kit"
+```
+
+---
+
+## Fase 1 — Backend: fundação de dados e schema
+
+### Task 1: Migration `005_boletins.sql`
+
+**Files:**
+- Create: `server/migrations/005_boletins.sql`
+
+- [ ] **Step 1: Escrever a migration** (segue o estilo de `004_media.sql`; aplicada no boot por `runMigrations`)
+
+```sql
+-- server/migrations/005_boletins.sql
+-- Boletim Informativo: editor de blocos + publicação (US-16/US-18/US-19).
+CREATE TABLE boletins (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title          text NOT NULL,
+  summary        text,
+  cover_media_id uuid REFERENCES media(id) ON DELETE SET NULL,
+  content        jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status         text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published')),
+  slug           text,
+  published_at   timestamptz,
+  created_by     uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Slug único apenas quando preenchido (rascunhos têm slug NULL).
+CREATE UNIQUE INDEX idx_boletins_slug ON boletins (slug) WHERE slug IS NOT NULL;
+-- Listagem pública/admin por estado e data.
+CREATE INDEX idx_boletins_status_published ON boletins (status, published_at DESC);
+CREATE INDEX idx_boletins_created_at ON boletins (created_at DESC);
+```
+
+- [ ] **Step 2: Verificar aplicação da migration**
+
+Run: `docker compose up --build db app` (ou subir o server local com Postgres) e conferir o log de `runMigrations` aplicando `005_boletins.sql` sem erro; `\d boletins` no psql mostra a tabela.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/migrations/005_boletins.sql
+git commit -m "feat(boletim): migration da tabela boletins (jsonb content + slug)"
+```
+
+### Task 2: Schema de blocos (Zod, fonte no server)
+
+**Files:**
+- Create: `server/modules/boletins/dto/block.schema.ts`
+- Create: `server/modules/boletins/dto/boletim.dto.ts`
+
+- [ ] **Step 1: Escrever o schema de blocos (discriminated union)**
+
+`server/modules/boletins/dto/block.schema.ts`:
+
+```ts
+import { z } from 'zod'
+
+/** Extrai o videoId de uma URL do YouTube (watch, youtu.be, embed, shorts). */
+export function extractYouTubeId(input: string): string | null {
+  const s = input.trim()
+  // já é um id puro (11 chars base64url)
+  if (/^[a-zA-Z0-9_-]{11}$/.test(s)) return s
+  const patterns = [
+    /[?&]v=([a-zA-Z0-9_-]{11})/,
+    /youtu\.be\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ]
+  for (const p of patterns) {
+    const m = s.match(p)
+    if (m) return m[1]
+  }
+  return null
+}
+
+const youtubeId = z.string().regex(/^[a-zA-Z0-9_-]{11}$/, 'Vídeo do YouTube inválido.')
+
+const headingBlock = z.object({
+  id: z.string(),
+  type: z.literal('heading'),
+  props: z.object({ text: z.string().max(200), level: z.union([z.literal(2), z.literal(3)]) }),
+})
+
+const textBlock = z.object({
+  id: z.string(),
+  type: z.literal('text'),
+  // doc do TipTap/ProseMirror — validação permissiva (objeto). O conteúdo é renderizado
+  // por mapeamento de nós no client, nunca como HTML cru.
+  props: z.object({ doc: z.record(z.string(), z.unknown()) }),
+})
+
+const imageBlock = z.object({
+  id: z.string(),
+  type: z.literal('image'),
+  props: z.object({ mediaId: z.string().uuid(), alt: z.string().max(200).default('') }),
+})
+
+const galleryBlock = z.object({
+  id: z.string(),
+  type: z.literal('gallery'),
+  props: z.object({ mediaIds: z.array(z.string().uuid()).min(1).max(30) }),
+})
+
+const videoBlock = z.object({
+  id: z.string(),
+  type: z.literal('video'),
+  props: z.object({ youtubeId }),
+})
+
+export const blockSchema = z.discriminatedUnion('type', [
+  headingBlock, textBlock, imageBlock, galleryBlock, videoBlock,
+])
+export type Block = z.infer<typeof blockSchema>
+
+export const contentSchema = z.array(blockSchema)
+```
+
+- [ ] **Step 2: Escrever os DTOs de criar/atualizar/publicar/listar**
+
+`server/modules/boletins/dto/boletim.dto.ts`:
+
+```ts
+import { z } from 'zod'
+import { paginationQuery } from '../../../core/pagination.js'
+import { contentSchema } from './block.schema.js'
+
+export const createBoletimDto = z.object({
+  title: z.string().trim().min(1, 'Título é obrigatório.').max(200),
+})
+export type CreateBoletimDto = z.infer<typeof createBoletimDto>
+
+export const updateBoletimDto = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  summary: z.string().trim().max(500).nullable().optional(),
+  coverMediaId: z.string().uuid().nullable().optional(),
+  content: contentSchema.optional(),
+})
+export type UpdateBoletimDto = z.infer<typeof updateBoletimDto>
+
+export const listBoletinsQuery = paginationQuery
+export type ListBoletinsQuery = z.infer<typeof listBoletinsQuery>
+```
+
+- [ ] **Step 3: Verificar build do server**
+
+Run: `npm run build`
+Expected: `tsc -p tsconfig.server.json` compila os DTOs sem erro.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/modules/boletins/dto/
+git commit -m "feat(boletim): schema Zod dos blocos + DTOs (server)"
+```
+
+### Task 3: Função pura de slug
+
+**Files:**
+- Create: `server/modules/boletins/boletins.slug.ts`
+
+- [ ] **Step 1: Escrever o slugify (transliteração nativa, sem deps)**
+
+```ts
+// server/modules/boletins/boletins.slug.ts
+/** Gera um slug legível e seguro para URL a partir de um título (sem acentos/especiais). */
+export function slugify(title: string): string {
+  const base = title
+    .normalize('NFD').replace(/[̀-ͯ]/g, '') // remove diacríticos
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') // não-alfanumérico → hífen
+    .replace(/^-+|-+$/g, '')     // tira hífens das pontas
+    .slice(0, 80)
+  return base || 'boletim'
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build` → passa.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/modules/boletins/boletins.slug.ts
+git commit -m "feat(boletim): slugify com transliteração nativa"
+```
+
+### Task 4: Repository
+
+**Files:**
+- Create: `server/modules/boletins/boletins.repository.ts`
+
+- [ ] **Step 1: Escrever o repository** (único ponto com SQL; segue estilo de `media.repository.ts`)
+
+```ts
+import type { Pool } from 'pg'
+import type { Block } from './dto/block.schema.js'
+
+export interface BoletimRow {
+  id: string
+  title: string
+  summary: string | null
+  cover_media_id: string | null
+  content: Block[]
+  status: 'draft' | 'published'
+  slug: string | null
+  published_at: Date | null
+  created_by: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface UpdateBoletimFields {
+  title?: string
+  summary?: string | null
+  coverMediaId?: string | null
+  content?: Block[]
+}
+
+export class BoletinsRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(title: string, createdBy: string): Promise<BoletimRow> {
+    const r = await this.pool.query<BoletimRow>(
+      `INSERT INTO boletins (title, created_by) VALUES ($1, $2) RETURNING *`,
+      [title, createdBy],
+    )
+    return r.rows[0]
+  }
+
+  async findById(id: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>('SELECT * FROM boletins WHERE id = $1', [id])
+    return r.rows[0] ?? null
+  }
+
+  async findPublishedBySlug(slug: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `SELECT * FROM boletins WHERE slug = $1 AND status = 'published'`, [slug],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async list({ limit, offset }: { limit: number; offset: number }): Promise<{ rows: BoletimRow[]; total: number }> {
+    const rows = await this.pool.query<BoletimRow>(
+      `SELECT * FROM boletins ORDER BY created_at DESC LIMIT $1 OFFSET $2`, [limit, offset],
+    )
+    const count = await this.pool.query<{ count: number }>('SELECT count(*)::int AS count FROM boletins')
+    return { rows: rows.rows, total: count.rows[0].count }
+  }
+
+  /** Atualiza somente os campos fornecidos; sempre toca updated_at. */
+  async update(id: string, f: UpdateBoletimFields): Promise<BoletimRow | null> {
+    const sets: string[] = []
+    const vals: unknown[] = []
+    let i = 1
+    if (f.title !== undefined) { sets.push(`title = $${i++}`); vals.push(f.title) }
+    if (f.summary !== undefined) { sets.push(`summary = $${i++}`); vals.push(f.summary) }
+    if (f.coverMediaId !== undefined) { sets.push(`cover_media_id = $${i++}`); vals.push(f.coverMediaId) }
+    if (f.content !== undefined) { sets.push(`content = $${i++}::jsonb`); vals.push(JSON.stringify(f.content)) }
+    sets.push(`updated_at = now()`)
+    vals.push(id)
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`, vals,
+    )
+    return r.rows[0] ?? null
+  }
+
+  async setPublished(id: string, slug: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET status = 'published', slug = $1, published_at = now(), updated_at = now()
+       WHERE id = $2 RETURNING *`, [slug, id],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async setUnpublished(id: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET status = 'draft', updated_at = now() WHERE id = $1 RETURNING *`, [id],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM boletins WHERE id = $1', [id])
+  }
+
+  /** True se já existe um boletim usando este slug (qualquer estado). */
+  async slugExists(slug: string): Promise<boolean> {
+    const r = await this.pool.query('SELECT 1 FROM boletins WHERE slug = $1 LIMIT 1', [slug])
+    return r.rowCount! > 0
+  }
+
+  /**
+   * True se a mídia está em uso por QUALQUER boletim: como capa, ou dentro de content
+   * em bloco image (props.mediaId) ou gallery (props.mediaIds[]). Fecha CA-05 da US-17.
+   */
+  async mediaInUse(mediaId: string): Promise<boolean> {
+    const r = await this.pool.query(
+      `SELECT 1 FROM boletins b
+       WHERE b.cover_media_id = $1
+          OR EXISTS (
+            SELECT 1 FROM jsonb_array_elements(b.content) AS elem
+            WHERE elem->'props'->>'mediaId' = $1
+               OR elem->'props'->'mediaIds' ? $1
+          )
+       LIMIT 1`, [mediaId],
+    )
+    return r.rowCount! > 0
+  }
+}
+```
+
+- [ ] **Step 2: Build** → `npm run build` passa.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/modules/boletins/boletins.repository.ts
+git commit -m "feat(boletim): repository (CRUD + slug + mediaInUse JSONB)"
+```
+
+### Task 5: Service (regra de negócio)
+
+**Files:**
+- Create: `server/modules/boletins/boletins.service.ts`
+
+- [ ] **Step 1: Escrever o service** (regra: validação de publicação, slug+unicidade com retry, sugestão de capa, transições). Não conhece `req`/`res`.
+
+```ts
+import { BadRequestError, NotFoundError } from '../../core/errors.js'
+import { paginate, toOffset, type Paginated } from '../../core/pagination.js'
+import { slugify } from './boletins.slug.js'
+import type { BoletinsRepository, BoletimRow } from './boletins.repository.js'
+import type { Block } from './dto/block.schema.js'
+import type { CreateBoletimDto, UpdateBoletimDto, ListBoletinsQuery } from './dto/boletim.dto.js'
+
+export interface BoletimDTO {
+  id: string
+  title: string
+  summary: string | null
+  coverMediaId: string | null
+  content: Block[]
+  status: 'draft' | 'published'
+  slug: string | null
+  publicUrl: string | null
+  publishedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+const PG_UNIQUE_VIOLATION = '23505'
+
+export class BoletinsService {
+  constructor(
+    private readonly repo: BoletinsRepository,
+    private readonly publicBaseUrl: string,
+  ) {}
+
+  private toDTO = (row: BoletimRow): BoletimDTO => ({
+    id: row.id,
+    title: row.title,
+    summary: row.summary,
+    coverMediaId: row.cover_media_id,
+    content: row.content,
+    status: row.status,
+    slug: row.slug,
+    publicUrl: row.slug && row.status === 'published'
+      ? `${this.publicBaseUrl}/boletins/${row.slug}` : null,
+    publishedAt: row.published_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  })
+
+  async create(dto: CreateBoletimDto, userId: string): Promise<BoletimDTO> {
+    return this.toDTO(await this.repo.create(dto.title, userId))
+  }
+
+  async getById(id: string): Promise<BoletimDTO> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+    return this.toDTO(row)
+  }
+
+  async getPublishedBySlug(slug: string): Promise<BoletimDTO | null> {
+    const row = await this.repo.findPublishedBySlug(slug)
+    return row ? this.toDTO(row) : null
+  }
+
+  async list(params: ListBoletinsQuery): Promise<Paginated<BoletimDTO>> {
+    const { rows, total } = await this.repo.list({ limit: params.limit, offset: toOffset(params) })
+    return paginate(rows.map(this.toDTO), total, params)
+  }
+
+  async update(id: string, dto: UpdateBoletimDto): Promise<BoletimDTO> {
+    const current = await this.repo.findById(id)
+    if (!current) throw new NotFoundError('Boletim não encontrado.')
+
+    // Sugestão de capa: se não há capa (nem atual nem informada) e o conteúdo tem imagem, sugere a 1ª.
+    let coverMediaId = dto.coverMediaId
+    const content = dto.content
+    if (coverMediaId === undefined && !current.cover_media_id && content) {
+      const firstImg = firstImageMediaId(content)
+      if (firstImg) coverMediaId = firstImg
+    }
+
+    const updated = await this.repo.update(id, {
+      title: dto.title,
+      summary: dto.summary,
+      coverMediaId,
+      content,
+    })
+    return this.toDTO(updated!)
+  }
+
+  async publish(id: string): Promise<BoletimDTO> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+
+    // Bloqueio de publicação incompleta (CA-06 US-18): enumera o que falta.
+    const missing: string[] = []
+    if (!row.title?.trim()) missing.push('title')
+    if (!Array.isArray(row.content) || row.content.length === 0) missing.push('content')
+    if (!row.summary?.trim() && !row.cover_media_id) missing.push('summary/cover')
+    if (missing.length) {
+      throw new BadRequestError('Boletim incompleto para publicação.', { missing })
+    }
+
+    // Slug imutável após a 1ª publicação (CA-04 US-18): só gera se ainda não tem.
+    if (row.slug) {
+      return this.toDTO((await this.repo.setPublished(id, row.slug))!)
+    }
+    return this.toDTO(await this.publishWithUniqueSlug(id, row.title))
+  }
+
+  /** Gera slug único; o índice parcial é a fonte da verdade — retry em 23505. */
+  private async publishWithUniqueSlug(id: string, title: string): Promise<BoletimRow> {
+    const base = slugify(title)
+    let candidate = base
+    let n = 1
+    // pré-checagem barata para evitar a maioria das colisões
+    while (await this.repo.slugExists(candidate)) { n++; candidate = `${base}-${n}` }
+    for (;;) {
+      try {
+        return (await this.repo.setPublished(id, candidate))!
+      } catch (err) {
+        if ((err as { code?: string }).code === PG_UNIQUE_VIOLATION) {
+          n++; candidate = `${base}-${n}`; continue
+        }
+        throw err
+      }
+    }
+  }
+
+  async unpublish(id: string): Promise<BoletimDTO> {
+    const updated = await this.repo.setUnpublished(id)
+    if (!updated) throw new NotFoundError('Boletim não encontrado.')
+    return this.toDTO(updated)
+  }
+
+  async delete(id: string): Promise<void> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+    await this.repo.delete(id)
+  }
+}
+
+function firstImageMediaId(content: Block[]): string | null {
+  for (const b of content) {
+    if (b.type === 'image') return b.props.mediaId
+    if (b.type === 'gallery' && b.props.mediaIds.length) return b.props.mediaIds[0]
+  }
+  return null
+}
+```
+
+Nota: `BadRequestError` precisa aceitar um 2º argumento de `details`. Verificar a assinatura em `server/core/errors.ts`; se não aceitar, estender a classe `AppError`/`BadRequestError` para carregar `details` e o `error-handler.ts` repassá-lo no corpo `{ error, details }` (já usado em `/api/contato`). Ajuste mínimo e dentro do padrão.
+
+- [ ] **Step 2: Conferir/ajustar `BadRequestError` para `details`**
+
+Run: ler `server/core/errors.ts` e `server/core/error-handler.ts`. Se `details` não existir, adicionar campo opcional e repassá-lo na resposta. Build deve passar.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/modules/boletins/boletins.service.ts server/core/errors.ts server/core/error-handler.ts
+git commit -m "feat(boletim): service (publicação, slug único com retry, sugestão de capa)"
+```
+
+### Task 6: Controller + rotas
+
+**Files:**
+- Create: `server/modules/boletins/boletins.controller.ts`
+- Create: `server/modules/boletins/boletins.routes.ts`
+
+- [ ] **Step 1: Controller** (HTTP fino; valida DTO, chama service)
+
+```ts
+import type { Request, Response } from 'express'
+import { createBoletimDto, updateBoletimDto, listBoletinsQuery } from './dto/boletim.dto.js'
+import type { BoletinsService } from './boletins.service.js'
+
+export class BoletinsController {
+  constructor(private readonly service: BoletinsService) {}
+
+  create = async (req: Request, res: Response) => {
+    const dto = createBoletimDto.parse(req.body)
+    const created = await this.service.create(dto, req.user!.id)
+    res.status(201).json({ boletim: created })
+  }
+
+  list = async (req: Request, res: Response) => {
+    const params = listBoletinsQuery.parse(req.query)
+    res.json(await this.service.list(params))
+  }
+
+  get = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.getById(req.params.id) })
+  }
+
+  update = async (req: Request, res: Response) => {
+    const dto = updateBoletimDto.parse(req.body)
+    res.json({ boletim: await this.service.update(req.params.id, dto) })
+  }
+
+  publish = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.publish(req.params.id) })
+  }
+
+  unpublish = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.unpublish(req.params.id) })
+  }
+
+  remove = async (req: Request, res: Response) => {
+    await this.service.delete(req.params.id)
+    res.status(204).end()
+  }
+
+  // pública
+  getBySlug = async (req: Request, res: Response) => {
+    const boletim = await this.service.getPublishedBySlug(req.params.slug)
+    if (!boletim) { res.status(404).json({ error: 'Boletim não encontrado.' }); return }
+    res.json({ boletim })
+  }
+}
+```
+
+Nota: validar como o `req.user` é tipado nos outros controllers (usar o mesmo padrão; `parse` lança ZodError que o error-handler central traduz — conferir que ZodError já é tratado lá, como nos outros módulos).
+
+- [ ] **Step 2: Rotas** (espelha `media.routes.ts`: `wrap`, `requireAuth`, `requirePermission`, `requireCsrf` nas mutações)
+
+```ts
+import { Router, type RequestHandler } from 'express'
+import { requireCsrf } from '../auth/middleware/require-csrf.js'
+import type { BoletinsController } from './boletins.controller.js'
+
+const wrap = (h: RequestHandler): RequestHandler => (req, res, next) =>
+  Promise.resolve(h(req, res, next)).catch(next)
+
+/** Montado em /api/admin. */
+export function makeBoletinsAdminRoutes(
+  c: BoletinsController,
+  requireAuth: RequestHandler,
+  requirePermission: (key: string) => RequestHandler,
+): Router {
+  const r = Router()
+  const write = requirePermission('boletim:write')
+  const publish = requirePermission('boletim:publish')
+  r.get('/boletins', wrap(requireAuth), write, wrap(c.list))
+  r.post('/boletins', wrap(requireAuth), write, requireCsrf, wrap(c.create))
+  r.get('/boletins/:id', wrap(requireAuth), write, wrap(c.get))
+  r.patch('/boletins/:id', wrap(requireAuth), write, requireCsrf, wrap(c.update))
+  r.post('/boletins/:id/publish', wrap(requireAuth), publish, requireCsrf, wrap(c.publish))
+  r.post('/boletins/:id/unpublish', wrap(requireAuth), publish, requireCsrf, wrap(c.unpublish))
+  r.delete('/boletins/:id', wrap(requireAuth), write, requireCsrf, wrap(c.remove))
+  return r
+}
+
+/** Montado em /api/boletins (pública, sem auth/CSRF). */
+export function makeBoletinsPublicRoutes(c: BoletinsController): Router {
+  const r = Router()
+  r.get('/:slug', wrap(c.getBySlug))
+  return r
+}
+```
+
+- [ ] **Step 3: Build** → passa.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/modules/boletins/boletins.controller.ts server/modules/boletins/boletins.routes.ts
+git commit -m "feat(boletim): controller + rotas admin/públicas"
+```
+
+### Task 7: Permissão `boletim:publish` + usage checker + wiring no container + mount
+
+**Files:**
+- Create: `server/modules/boletins/boletins.usage.ts`
+- Modify: `server/seed/permissions.catalog.ts`
+- Modify: `server/container.ts`
+- Modify: `server/index.ts`
+- Modify: `server/core/config.ts` (env `PUBLIC_BASE_URL`)
+
+- [ ] **Step 1: Adicionar permissão ao catálogo**
+
+Em `server/seed/permissions.catalog.ts`, adicionar após `boletim:write`:
+
+```ts
+  { key: 'boletim:publish', description: 'Publicar/despublicar boletins' },
+```
+
+(O seed `linkAllPermissions` religa ao `admin` no próximo boot.)
+
+- [ ] **Step 2: Usage checker (fecha CA-05 US-17)**
+
+`server/modules/boletins/boletins.usage.ts`:
+
+```ts
+import type { MediaUsageChecker } from '../media/media.service.js'
+import type { BoletinsRepository } from './boletins.repository.js'
+
+/** Bloqueia exclusão de imagem usada como capa ou dentro de algum boletim. */
+export function makeBoletinMediaUsageChecker(repo: BoletinsRepository): MediaUsageChecker {
+  return (mediaId: string) => repo.mediaInUse(mediaId)
+}
+```
+
+- [ ] **Step 3: Env `PUBLIC_BASE_URL` em `config.ts`**
+
+Adicionar em `server/core/config.ts` um campo `publicBaseUrl: process.env.PUBLIC_BASE_URL ?? ''` (string vazia em dev → `publicUrl` relativo; em prod recebe a URL absoluta). Conferir o padrão de leitura de env existente no arquivo.
+
+- [ ] **Step 4: Wiring no `container.ts`**
+
+```ts
+// imports (topo)
+import { BoletinsRepository } from './modules/boletins/boletins.repository.js'
+import { BoletinsService } from './modules/boletins/boletins.service.js'
+import { BoletinsController } from './modules/boletins/boletins.controller.js'
+import { makeBoletinsAdminRoutes, makeBoletinsPublicRoutes } from './modules/boletins/boletins.routes.js'
+import { makeBoletinMediaUsageChecker } from './modules/boletins/boletins.usage.js'
+
+// --- Boletim (US-16/18/19) ---
+const boletinsRepo = new BoletinsRepository(pool)
+const boletinsService = new BoletinsService(boletinsRepo, config.publicBaseUrl)
+const boletinsController = new BoletinsController(boletinsService)
+export const boletinsAdminRoutes = makeBoletinsAdminRoutes(boletinsController, requireAuth, requirePermission)
+export const boletinsPublicRoutes = makeBoletinsPublicRoutes(boletinsController)
+```
+
+E plugar o checker na construção do `MediaService` (linha 80). Como o `boletinsRepo` precisa existir antes, reordenar: criar `boletinsRepo` **antes** do bloco de mídia, e trocar:
+
+```ts
+const mediaService = new MediaService(mediaRepo, [makeBoletinMediaUsageChecker(boletinsRepo)])
+```
+
+Exportar também `boletinsService` para o uso no OG (Task 12):
+
+```ts
+export { boletinsService }
+```
+
+- [ ] **Step 5: Montar rotas em `server/index.ts`**
+
+No import do `./container.js`, acrescentar `boletinsAdminRoutes, boletinsPublicRoutes`. Depois de `app.use('/api/admin', mediaAdminRoutes)`:
+
+```ts
+app.use('/api/admin', boletinsAdminRoutes)
+```
+
+E depois de `app.use('/media', mediaPublicRoutes)`:
+
+```ts
+app.use('/api/boletins', boletinsPublicRoutes)
+```
+
+- [ ] **Step 6: Verificar o ciclo completo via API**
+
+Run: subir o server. Com cookie de admin + CSRF: `POST /api/admin/boletins {title}` → 201; `PATCH` com content; `POST .../publish` → slug gerado; `GET /api/boletins/:slug` → 200; após `unpublish` → 404. Excluir mídia em uso → 409 (ConflictError).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/modules/boletins/boletins.usage.ts server/seed/permissions.catalog.ts server/container.ts server/index.ts server/core/config.ts
+git commit -m "feat(boletim): permissão publish, usage checker de mídia e wiring no container"
+```
+
+---
+
+## Fase 2 — Frontend: schema espelho, API client e renderer compartilhado
+
+### Task 8: Schema de blocos (espelho client) + API client
+
+**Files:**
+- Create: `src/schemas/boletim.ts`
+- Create: `src/painel/boletim-api.ts`
+
+- [ ] **Step 1: Espelhar tipos de bloco no client** (`src/schemas/boletim.ts`)
+
+Replicar `Block`/`extractYouTubeId` do server (mesma união discriminada). Manter em sincronia com `server/modules/boletins/dto/block.schema.ts` (convenção do projeto). Pode reusar Zod ou só os tipos TS + `extractYouTubeId`.
+
+- [ ] **Step 2: API client** (`src/painel/boletim-api.ts`, espelha `media-api.ts`)
+
+```ts
+import { adminFetch } from '@/painel/admin-api'
+import type { PageInfo } from '@/painel/usePagination'
+import type { Block } from '@/schemas/boletim'
+
+export interface Boletim {
+  id: string; title: string; summary: string | null; coverMediaId: string | null
+  content: Block[]; status: 'draft' | 'published'; slug: string | null
+  publicUrl: string | null; publishedAt: string | null; createdAt: string; updatedAt: string
+}
+
+export async function listBoletins(page: number, limit: number) { /* GET /boletins?page=&limit= → {data,pagination} */ }
+export async function createBoletim(title: string): Promise<Boletim> { /* POST /boletins */ }
+export async function getBoletim(id: string): Promise<Boletim> { /* GET /boletins/:id */ }
+export async function updateBoletim(id: string, patch: Partial<Pick<Boletim,'title'|'summary'|'coverMediaId'|'content'>>): Promise<Boletim> { /* PATCH */ }
+export async function publishBoletim(id: string): Promise<Boletim> { /* POST /boletins/:id/publish */ }
+export async function unpublishBoletim(id: string): Promise<Boletim> { /* POST /boletins/:id/unpublish */ }
+export async function deleteBoletim(id: string): Promise<void> { /* DELETE */ }
+```
+
+Implementar cada função no padrão de `media-api.ts` (tratar `res.ok`, extrair `.boletim`/envelope; em erro, ler `body.error`). Em publish incompleto (400), repassar `body.details.missing` para a UI exibir o que falta.
+
+- [ ] **Step 3: Build** → passa.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/schemas/boletim.ts src/painel/boletim-api.ts
+git commit -m "feat(boletim): tipos de bloco (client) e API client"
+```
+
+### Task 9: Renderer compartilhado de blocos
+
+**Files:**
+- Create: `src/components/boletim/BulletinRenderer.tsx`
+- Create: `src/components/boletim/blocks/` (um componente por tipo)
+
+- [ ] **Step 1: Componentes de bloco** (on-brand, responsivos, **client-only**)
+
+- `HeadingBlock` → `<h2>/<h3>` com Montserrat.
+- `TextBlock` → renderiza o `doc` TipTap via `generateHTML(doc, [StarterKit, Link])` do `@tiptap/html`, dentro de um container `prose`-like estilizado on-brand. (Mesmo conjunto de extensões do editor — Task 11.) Links com `rel="noopener nofollow"`.
+- `ImageBlock` → `<img src={`/media/${mediaId}`} alt loading="lazy">` responsivo.
+- `GalleryBlock` → grade responsiva (`grid grid-cols-2 md:grid-cols-3 gap-2`) de `/media/:id`.
+- `VideoBlock` → embed YouTube responsivo (`aspect-video` + iframe `https://www.youtube.com/embed/${youtubeId}`), reaproveitando o padrão de `AoVivo.tsx`.
+
+- [ ] **Step 2: `BulletinRenderer`** (recebe `content: Block[]`, faz `switch (block.type)` mapeando para os componentes; `max-w` e espaçamento consistentes com o site).
+
+- [ ] **Step 3: Build** → passa. Verificação visual ocorre quando o editor/página usarem o renderer (Tasks 11/13).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/boletim/
+git commit -m "feat(boletim): renderer compartilhado de blocos"
+```
+
+---
+
+## Fase 3 — Frontend: editor e gestão mínima
+
+### Task 10: MediaPicker (fecha CA-04 US-17)
+
+**Files:**
+- Create: `src/painel/components/MediaPicker.tsx`
+
+- [ ] **Step 1: Modal-picker da biblioteca** sobre `listMedia` (grade paginada + busca por nome, reusando `usePagination` e o kit `Modal`/`Field`/`Input`/`Pager`/`Spinner`).
+  - Prop `multiple?: boolean`: `false` → seleciona 1 (`onSelect(id)`); `true` → seleciona N com confirmação (`onSelect(ids[])`).
+  - Reaproveita os cards de miniatura no padrão de `Midia.tsx`.
+
+- [ ] **Step 2: Build** → passa.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/painel/components/MediaPicker.tsx
+git commit -m "feat(boletim): MediaPicker reutilizável (CA-04 US-17)"
+```
+
+### Task 11: Editor de boletim (`/painel/boletins/:id`)
+
+**Files:**
+- Create: `src/painel/pages/BoletimEditor.tsx`
+- Create: `src/painel/components/blocks/` (editores por tipo: TextBlockEditor com TipTap, etc.)
+- Create: `src/painel/components/BlockList.tsx` (lista com @dnd-kit/sortable)
+
+- [ ] **Step 1: TextBlockEditor (TipTap)** — `useEditor({ extensions: [StarterKit, Link.configure({...})], content: doc, onUpdate: e => onChange(e.getJSON()) })` + toolbar (negrito/itálico/lista/link). Exportar o doc como JSON para `props.doc`.
+
+- [ ] **Step 2: BlockList com drag-and-drop** — `DndContext` + `SortableContext` (`@dnd-kit/sortable`), cada item com handle de arraste e botão remover; `onDragEnd` reordena o array (`arrayMove`). Botão "adicionar bloco" (escolhe tipo; insere no fim ou em posição).
+
+- [ ] **Step 3: Editores dos demais blocos** — heading (input + nível), image (botão → `MediaPicker` single + campo alt), gallery (botão → `MediaPicker` multiple), video (input de URL → `extractYouTubeId`; recusa inválido com mensagem — CA-09).
+
+- [ ] **Step 4: Página do editor** — carrega `getBoletim(id)`; painel de metadados (título, resumo, capa via `MediaPicker` single, com sugestão da 1ª imagem); `BlockList`; **pré-visualização** com `BulletinRenderer`; botão Salvar (`updateBoletim`, validação título+≥1 bloco com mensagens claras — CA-07); botões Publicar/Despublicar (mostra `missing` em 400); Copiar link + WhatsApp quando publicado; indicador de slug travado após publicado (CA-04 US-18). Tudo com o kit de UI.
+
+- [ ] **Step 5: Build + verificação manual** — `npm run dev` + `dev:server`: criar boletim, adicionar cada tipo de bloco, formatar texto, reordenar por arraste, salvar, reabrir (conteúdo intacto), pré-visualização fiel.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/painel/pages/BoletimEditor.tsx src/painel/components/blocks/ src/painel/components/BlockList.tsx
+git commit -m "feat(boletim): editor de blocos (TipTap + dnd-kit + picker + preview)"
+```
+
+### Task 12: Lista no painel + nav + rotas
+
+**Files:**
+- Create: `src/painel/pages/Boletins.tsx`
+- Modify: `src/painel/nav-config.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Página de lista** (`Boletins.tsx`) — `PageHeader` + "Novo boletim" (`createBoletim` → navega ao editor); tabela/cards com título, `StatusBadge` (rascunho/publicado), data, e ações (editar, publicar/despublicar, copiar link, excluir com confirmação); `Pager`. Kit de UI.
+
+- [ ] **Step 2: Item no menu lateral** — em `nav-config.tsx`, adicionar entrada `{ key: 'boletins', label: 'Boletins', icon: icon(I.<novo>), to: '/painel/boletins', perm: 'boletim:write' }` (adicionar um path de ícone novo em `I`).
+
+- [ ] **Step 3: Rotas no `App.tsx`** — dentro do `<Route path="/painel" ...>`:
+
+```tsx
+<Route path="boletins" element={<RequirePermission perm="boletim:write"><Boletins /></RequirePermission>} />
+<Route path="boletins/:id" element={<RequirePermission perm="boletim:write"><BoletimEditor /></RequirePermission>} />
+```
+
+- [ ] **Step 4: Build + verificação** — menu mostra "Boletins" só com permissão; navegação lista↔editor funciona; publicar/despublicar/copiar link refletem na lista.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/painel/pages/Boletins.tsx src/painel/nav-config.tsx src/App.tsx
+git commit -m "feat(boletim): lista no painel + item de menu + rotas"
+```
+
+---
+
+## Fase 4 — Página pública e Open Graph
+
+### Task 13: Página pública `/boletins/:slug`
+
+**Files:**
+- Create: `src/pages/BoletimPublico.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Página pública** — `useParams` slug; `fetch('/api/boletins/' + slug)` (rota pública, sem admin client); `Spinner` no load; em 404 → tela amigável "Boletim não encontrado"; em sucesso → `BulletinRenderer` do conteúdo, header/título on-brand. Sem autenticação.
+
+- [ ] **Step 2: Rota** — em `App.tsx`, fora do `/painel` (pode entrar no `PublicLayout` ou como rota própria): `<Route path="/boletins/:slug" element={<BoletimPublico />} />`.
+
+- [ ] **Step 3: Build + verificação** — publicar um boletim, abrir `/boletins/<slug>` no browser: renderiza todos os tipos de bloco, responsivo; rascunho/despublicado → 404.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/BoletimPublico.tsx src/App.tsx
+git commit -m "feat(boletim): página pública /boletins/:slug"
+```
+
+### Task 14: Injeção de Open Graph server-side (US-19 CA-02/03)
+
+**Files:**
+- Create: `server/lib/og.ts` (helper de injeção, função pura)
+- Modify: `server/index.ts`
+
+- [ ] **Step 1: Helper de injeção** (`server/lib/og.ts`) — função `injectOgTags(html: string, meta: {...}): string` que insere as meta tags no `<head>` com valores **escapados** (escape de `&"<>`): `og:title`, `og:description`, `og:image`, `og:url`, `og:type=article`, e `twitter:card=summary_large_image` + equivalentes.
+
+- [ ] **Step 2: Rota OG no bloco de produção** — em `server/index.ts`, **dentro** do `if (process.env.NODE_ENV === 'production')`, **antes** do `app.get('{*path}', …)`:
+
+```ts
+import { readFileSync } from 'fs'
+import { boletinsService } from './container.js' // já exportado na Task 7
+import { injectOgTags } from './lib/og.js'
+// ...
+app.get('/boletins/:slug', async (req, res, next) => {
+  try {
+    const boletim = await boletinsService.getPublishedBySlug(req.params.slug)
+    if (!boletim) return next() // cai no catch-all SPA → 404 do React
+    const html = readFileSync(path.join(distPath, 'index.html'), 'utf8')
+    const base = process.env.PUBLIC_BASE_URL ?? ''
+    const cover = boletim.coverMediaId ? `${base}/media/${boletim.coverMediaId}` : `${base}/img/logo-iasd.png`
+    res.send(injectOgTags(html, {
+      title: boletim.title,
+      description: boletim.summary ?? '',
+      image: cover,
+      url: `${base}/boletins/${boletim.slug}`,
+    }))
+  } catch (err) { next(err) }
+})
+```
+
+- [ ] **Step 3: Verificação em produção** — `docker compose up --build`; `curl -s http://localhost:3001/boletins/<slug> | grep og:` mostra as tags preenchidas (JS desligado); rascunho → sem vazamento (SPA 404). Validar o cartão no preview do WhatsApp/validador de OG.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/lib/og.ts server/index.ts
+git commit -m "feat(boletim): Open Graph server-side para /boletins/:slug (US-19)"
+```
+
+---
+
+## Fase 5 — Documentação e fechamento
+
+### Task 15: Docs, env e DoD
+
+**Files:**
+- Modify: `docs/historias/US-16-editor-boletim.md`, `US-18-...`, `US-19-...`, `US-17-...` (marcar DoD entregue)
+- Modify: `docs/historias/README.md` (status ✅ + commits)
+- Modify: `.env.example` / `deploy.sh` (documentar `PUBLIC_BASE_URL`)
+- Modify: `CLAUDE.md` (registrar a feature do Boletim e o padrão de blocos, se aplicável)
+- Modify: `docker-compose.yml` (garantir `PUBLIC_BASE_URL` no serviço `app`, se houver lista de env)
+
+- [ ] **Step 1: Marcar DoD** das US-16/18/19 e os itens CA-04/CA-05 da US-17; atualizar a tabela do `README.md` (status e commits principais).
+
+- [ ] **Step 2: Documentar `PUBLIC_BASE_URL`** em `.env.example`/`deploy.sh`/compose (URL pública absoluta para OG).
+
+- [ ] **Step 3: Build final** → `npm run build` passa; revisão geral.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ .env.example deploy.sh CLAUDE.md docker-compose.yml
+git commit -m "docs(boletim): DoD das US-16/18/19, fecha CA-04/05 da US-17, env PUBLIC_BASE_URL"
+```
+
+### Task 16: Revisão de código e PR
+
+- [ ] **Step 1:** Usar superpowers:requesting-code-review para revisar o diff completo da branch.
+- [ ] **Step 2:** Endereçar achados (com superpowers:receiving-code-review).
+- [ ] **Step 3:** Usar superpowers:finishing-a-development-branch para abrir o PR de `feat/boletim` → `master`.
+
+---
+
+## Resumo de arquivos
+
+**Backend (novos):** `server/migrations/005_boletins.sql`, `server/modules/boletins/{boletins.repository,boletins.service,boletins.controller,boletins.routes,boletins.slug,boletins.usage}.ts`, `server/modules/boletins/dto/{block.schema,boletim.dto}.ts`, `server/lib/og.ts`.
+**Backend (modificados):** `server/container.ts`, `server/index.ts`, `server/seed/permissions.catalog.ts`, `server/core/config.ts`, possivelmente `server/core/errors.ts`+`error-handler.ts` (details).
+**Frontend (novos):** `src/schemas/boletim.ts`, `src/painel/boletim-api.ts`, `src/components/boletim/**`, `src/painel/components/{MediaPicker,BlockList}.tsx`, `src/painel/components/blocks/**`, `src/painel/pages/{Boletins,BoletimEditor}.tsx`, `src/pages/BoletimPublico.tsx`.
+**Frontend (modificados):** `src/App.tsx`, `src/painel/nav-config.tsx`.
+**Docs/infra:** `docs/historias/*`, `.env.example`, `deploy.sh`, `docker-compose.yml`, `CLAUDE.md`.

--- a/docs/superpowers/plans/2026-06-16-boletim.md
+++ b/docs/superpowers/plans/2026-06-16-boletim.md
@@ -31,7 +31,7 @@
 npm install @tiptap/react @tiptap/pm @tiptap/starter-kit @tiptap/extension-link @tiptap/html @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
 ```
 
-Nota: `@tiptap/pm` é peer-dep do TipTap; `@tiptap/html` faz `generateHTML` para o renderer. Backend não precisa de libs novas.
+Nota: `@tiptap/pm` é peer-dep do TipTap; `@tiptap/html` faz `generateHTML` para o renderer. Backend não precisa de libs novas. **Verificar a major instalada:** `generateHTML` vive em `@tiptap/html` no TipTap **v2**; se o npm trouxer v3 (que reorganizou pacotes), fixar a linha v2 (`@tiptap/react@^2 @tiptap/starter-kit@^2 ...`) para o import do renderer (Task 9) e do editor (Task 11) baterem.
 
 - [ ] **Step 2: Verificar build limpo**
 
@@ -354,6 +354,9 @@ export class BoletinsRepository {
           )
        LIMIT 1`, [mediaId],
     )
+    // Nota: `content` é NOT NULL DEFAULT '[]' e o repo só escreve arrays, então
+    // jsonb_array_elements é seguro. O operador `?` testa pertinência de string no array
+    // (gallery) e o `->>` compara a string (image). `$1` é placeholder pg, sem conflito com `?`.
     return r.rowCount! > 0
   }
 }
@@ -522,11 +525,29 @@ function firstImageMediaId(content: Block[]): string | null {
 }
 ```
 
-Nota: `BadRequestError` precisa aceitar um 2º argumento de `details`. Verificar a assinatura em `server/core/errors.ts`; se não aceitar, estender a classe `AppError`/`BadRequestError` para carregar `details` e o `error-handler.ts` repassá-lo no corpo `{ error, details }` (já usado em `/api/contato`). Ajuste mínimo e dentro do padrão.
+**IMPORTANTE (confirmado na revisão):** hoje `BadRequestError extends AppError` e o construtor de `AppError` aceita **só `message`**; o `error-handler.ts` responde `{ error }` sem `details` para `AppError` genérico (só `ValidationError`/`ZodError` carregam `details`, e ambos respondem **422**). Logo, `new BadRequestError('...', { missing })` **não compila** sem o ajuste abaixo — esta alteração é **obrigatória**, não opcional. Mantemos o status **400** para o erro de publicação incompleta (contrato `{ error, details }`), distinto do 422 da validação Zod.
 
-- [ ] **Step 2: Conferir/ajustar `BadRequestError` para `details`**
+- [ ] **Step 2: Estender `BadRequestError` com `details` e repassar no handler (obrigatório)**
 
-Run: ler `server/core/errors.ts` e `server/core/error-handler.ts`. Se `details` não existir, adicionar campo opcional e repassá-lo na resposta. Build deve passar.
+Em `server/core/errors.ts`, dar a `BadRequestError` um campo `details` (espelhando `ValidationError`):
+
+```ts
+export class BadRequestError extends AppError {
+  readonly status = 400
+  constructor(message: string, readonly details?: unknown) { super(message) }
+}
+```
+
+Em `server/core/error-handler.ts`, **antes** do branch genérico de `AppError` (porque `BadRequestError instanceof AppError` é true e seria engolido), importar `BadRequestError` e adicionar:
+
+```ts
+if (err instanceof BadRequestError) {
+  res.status(400).json({ error: err.message, details: err.details })
+  return
+}
+```
+
+Conferir a assinatura real de `AppError`/`status` ao editar (manter o padrão das outras subclasses). Build deve passar.
 
 - [ ] **Step 3: Commit**
 
@@ -769,7 +790,7 @@ export async function unpublishBoletim(id: string): Promise<Boletim> { /* POST /
 export async function deleteBoletim(id: string): Promise<void> { /* DELETE */ }
 ```
 
-Implementar cada função no padrão de `media-api.ts` (tratar `res.ok`, extrair `.boletim`/envelope; em erro, ler `body.error`). Em publish incompleto (400), repassar `body.details.missing` para a UI exibir o que falta.
+Implementar cada função no padrão de `media-api.ts` (tratar `res.ok`, extrair `.boletim`/envelope; em erro, ler `body.error`). **Distinguir dois códigos de erro:** validação de schema chega como **422** (`body.details.fieldErrors`, ZodError tratado no handler central); a publicação incompleta chega como **400** com `body.details.missing` (array de campos: `title`/`content`/`summary/cover`). A UI usa o 400/`missing` para mostrar o que falta para publicar (CA-06 US-18).
 
 - [ ] **Step 3: Build** → passa.
 

--- a/docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md
+++ b/docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md
@@ -1,0 +1,295 @@
+# Spec — Boletim: editor de blocos, publicação e página pública (US-16 + US-18 + US-19)
+
+- **Data:** 2026-06-16
+- **Branch:** a criar (ex.: `feat/boletim`)
+- **Histórias cobertas:** US-16 (editor de blocos), US-18 (publicar + slug), US-19 (página pública + Open Graph). Fecha também os itens adiados da **US-17**: CA-04 (modal-picker no editor) e CA-05 (bloqueio real de imagem em uso).
+- **Épico:** Boletim Informativo — **sub-projeto 3 de 5** (decomposição abaixo)
+- **Referência de arquitetura:** `CLAUDE.md` → seção *Backend — Área Administrativa, Autenticação e RBAC*
+- **Referência visual:** `docs/patterns/area-administrativa-visual.md`
+- **Backlog:** `docs/historias/US-16-editor-boletim.md`, `US-18-publicar-gerar-link.md`, `US-19-pagina-publica-preview.md`
+
+---
+
+## 1. Objetivo e contexto
+
+O Boletim é o artigo semanal compartilhado no grupo de WhatsApp da igreja. Este sub-projeto
+entrega o ciclo completo de produção e distribuição: o **administrador monta** o conteúdo
+empilhando blocos discretos (US-16), **publica** gerando um link estável baseado no título
+(US-18), e o **membro abre** uma página pública bonita com **cartão de preview** correto no
+WhatsApp (US-19).
+
+As três histórias são fortemente acopladas e tratadas como um sub-projeto único porque
+compartilham o mesmo registro e o mesmo *renderer*: o editor produz um JSON de blocos,
+publicar é só uma transição de estado desse registro, e a página pública renderiza **o mesmo
+JSON** com **o mesmo componente** usado na pré-visualização do editor — garantindo fidelidade.
+
+A fundação de mídia (US-17) já está entregue (`feat/biblioteca-midia`) e deixou dois ganchos
+que este sub-projeto consome: o endpoint de listagem `GET /api/admin/media` (para o picker) e
+o **registry de usage checkers** vazio no `MediaService` (para o bloqueio de remoção).
+
+### Decomposição do épico (contexto — este spec é o item 3)
+
+1. Fundação + editor de blocos (US-16 core) — *absorvido neste sub-projeto*
+2. Biblioteca de mídia (US-17) — **entregue**
+3. **Editor + publicação + página pública + Open Graph (US-16 + US-18 + US-19) — ESTE SPEC**
+4. Gerenciar boletins + templates (US-20 + US-21)
+5. Encurtador de links (US-22)
+
+## 2. Escopo
+
+### Dentro do escopo
+
+| CA | História | Resumo |
+|---|---|---|
+| CA-01..09 | US-16 | Criar/editar boletim com blocos (Título, Texto, Imagem, Galeria, Vídeo); reordenar/remover; metadados (resumo/capa); salvar rascunho como JSON; validação. |
+| CA-01..06 | US-18 | Slug do título (sem acento/inválidos, único); publicar/despublicar com `published_at`; slug estável; bloqueio de publicação incompleta; guard `boletim:publish`. |
+| CA-01..05 | US-19 | Página pública `/boletins/:slug` renderizando os blocos on-brand; meta tags Open Graph servidas no HTML inicial; rascunhos → 404; botão "Copiar link". CA-06 (compartilhar no WhatsApp) incluído por baixo custo. |
+| CA-04 | US-17 | Modal-picker da biblioteca a partir do editor (bloco de Imagem e Galeria). |
+| CA-05 | US-17 | Bloqueio real de remoção de imagem em uso por boletim, via usage checker registrado no `MediaService`. |
+
+### Fora do escopo (próximos sub-projetos)
+
+- **US-20 — tela de gestão de boletins** (filtros, duplicar, indicadores). O endpoint de
+  **listagem paginada** já nasce aqui (o editor precisa listar), mas a tela rica de gestão e
+  ações extras ficam para o sub-projeto 4. A lista do painel neste spec é a mínima viável.
+- **US-21 — templates de boletim.**
+- **US-22 — encurtador de links.**
+
+## 3. Decisões de design (confirmadas no brainstorming)
+
+1. **Sub-projeto único** para US-16/18/19 — renderer e registro compartilhados.
+2. **Bloco de Texto com editor WYSIWYG (TipTap) → JSON** (ProseMirror doc), não HTML cru.
+   Toolbar com negrito, itálico, listas e links (CA-03). Renderização por um componente único;
+   sem `dangerouslySetInnerHTML` de HTML do usuário — mitiga XSS por construção.
+3. **Reordenação por drag-and-drop** (`@dnd-kit`), com botão de remover por bloco.
+4. **Permissões em português, alinhadas ao catálogo existente:** `boletim:write` (já existe) e
+   **`boletim:publish`** (novo). Não introduzir `bulletins:*` em inglês.
+5. **Slug** gerado com transliteração nativa (`String.prototype.normalize('NFD')` + remoção de
+   diacríticos/caracteres inválidos), unicidade por sufixo incremental no repositório. **Sem
+   dependência nova no backend.**
+6. **Slug imutável** após a 1ª publicação (preserva links já distribuídos — CA-04 da US-18).
+7. **OG injetado server-side** no `index.html` para `/boletins/:slug`, antes do fallback SPA;
+   o corpo continua hidratado pelo React (SSR apenas do `<head>`).
+
+## 4. Modelo de dados — `server/migrations/005_boletins.sql`
+
+Tabela `boletins`:
+
+| Coluna | Tipo | Notas |
+|---|---|---|
+| `id` | `uuid` PK (`gen_random_uuid()`) | |
+| `title` | `text` not null | título; base do slug |
+| `summary` | `text` null | resumo (CA-05 US-16 / `og:description`) |
+| `cover_media_id` | `uuid` FK → `media(id)` `ON DELETE SET NULL` | capa (CA-05 US-16 / `og:image`) |
+| `content` | `jsonb` not null default `'[]'::jsonb` | sequência ordenada de blocos |
+| `status` | `text` not null default `'draft'` | `draft` \| `published` (CHECK) |
+| `slug` | `text` null | setado na 1ª publicação; **único quando não nulo** |
+| `published_at` | `timestamptz` null | momento da publicação |
+| `created_by` | `uuid` FK → `users(id)` `ON DELETE SET NULL` | autor |
+| `created_at` | `timestamptz` not null default `now()` | |
+| `updated_at` | `timestamptz` not null default `now()` | atualizado em cada save |
+
+Índices: `CREATE UNIQUE INDEX ON boletins (slug) WHERE slug IS NOT NULL;`
+`CREATE INDEX ON boletins (status, published_at DESC);`
+`CREATE INDEX ON boletins (created_at DESC);` (ordenação da lista do painel).
+Segue o padrão das migrations `001`–`004`, aplicadas no boot por `runMigrations`
+(`server/core/db.ts`).
+
+## 5. Schema dos blocos (Zod — fonte no server, espelho no client)
+
+`content` é um array de blocos; cada bloco é `{ id: string, type, props }`. Discriminated union
+por `type` (validado com `z.discriminatedUnion`):
+
+| `type` | `props` | Notas |
+|---|---|---|
+| `heading` | `{ text: string, level: 2 \| 3 }` | título de seção |
+| `text` | `{ doc: <JSON TipTap/ProseMirror> }` | formatação rica (negrito/itálico/lista/link) |
+| `image` | `{ mediaId: uuid, alt: string }` | referência por id (US-17), não duplica arquivo |
+| `gallery` | `{ mediaIds: uuid[] (1..N) }` | grade responsiva |
+| `video` | `{ youtubeId: string }` | só YouTube; sem upload de vídeo |
+
+- **Fonte:** `server/modules/boletins/dto/block.schema.ts` (+ DTOs de criar/atualizar/publicar).
+- **Espelho client:** `src/schemas/boletim.ts` — mantidos em sincronia (convenção do projeto).
+- O `doc` do TipTap é validado de forma permissiva (objeto ProseMirror); o conteúdo textual é
+  sanitizado na renderização pelo próprio mapeamento de nós (não há injeção de HTML cru).
+- O `youtubeId` é extraído/validado de URLs do YouTube (watch, youtu.be, embed, shorts);
+  entradas inválidas → erro de validação (CA-09 US-16).
+
+## 6. Backend — `server/modules/boletins/`
+
+Arquitetura em camadas obrigatória (`routes → controller → service → repository → db`),
+montada no composition root `server/container.ts`.
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `boletins.routes.ts` | Liga rotas → controller; aplica `requireAuth` + `requirePermission('boletim:write'\|'boletim:publish')`. Rota pública separada sem guard. |
+| `boletins.controller.ts` | HTTP fino: valida DTO, chama service, monta resposta. Sem regra de negócio. |
+| `boletins.service.ts` | Regra: validação de conteúdo, geração de slug + unicidade, transições de estado (publish/unpublish), sugestão de capa (1ª imagem se vazia). Não conhece `req`/`res` nem SQL. |
+| `boletins.repository.ts` | Único ponto com SQL de `boletins` (create, get by id, get published by slug, list paginada, update content/metadata, set status/slug/published_at, delete, **checar uso de um mediaId**). |
+| `dto/` | Schemas Zod (blocos + DTOs). Lista reusa `paginationQuery` de `core/pagination.ts`. |
+| `boletins.slug.ts` | Função pura de slugify (transliteração + normalização). **Função, não classe** (regra anti-complexidade do `CLAUDE.md`). |
+| `boletins.usage.ts` | Função `makeBoletinMediaUsageChecker(repo)` → `MediaUsageChecker` para registrar no `MediaService`. |
+
+**Regras de negócio principais:**
+
+- **Criar:** exige `title`; nasce `draft`, `content` `[]`, sem slug. (CA-01 US-16)
+- **Salvar (PATCH):** persiste `content` (blocos) + metadados (`title`, `summary`,
+  `cover_media_id`); atualiza `updated_at`. Validação Zod do array de blocos. (CA-06/07 US-16)
+- **Sugestão de capa:** se `cover_media_id` vazio, o service sugere o `mediaId` do primeiro
+  bloco `image`/`gallery` (não sobrescreve escolha explícita). (CA-05 US-16)
+- **Publicar:** requer `title`, ≥1 bloco e metadados mínimos (resumo/capa para o preview);
+  senão `BadRequestError` indicando o que falta. Na **1ª** publicação gera `slug` (slugify +
+  unicidade com sufixo `-2`, `-3`…); define `status='published'` e `published_at=now()`.
+  Em republicações o slug **não muda**. Guard `boletim:publish`. (CA-01..03/06 US-18)
+- **Despublicar:** volta a `draft`; o link público deixa de exibir (mantém o slug salvo para
+  reuso, mas a rota pública passa a 404 por causa do `status`). (CA-05 US-18)
+- **Slug estável:** editar o título depois **não** altera o slug. (CA-04 US-18)
+
+**Usage checker de mídia (fecha CA-05 US-17):** `boletins.usage.ts` expõe um checker que
+consulta se um `mediaId` aparece como `cover_media_id`, ou dentro de `content` em bloco
+`image`/`gallery` de **qualquer** boletim (consulta JSONB no repositório). Registrado no array
+`usageCheckers` do `MediaService` no `container.ts` (hoje `[]`). Resultado: excluir imagem em
+uso passa a lançar `ConflictError` **sem alterar o módulo de mídia**.
+
+**Rotas:**
+
+| Método | Rota | Auth | Descrição |
+|---|---|---|---|
+| `POST` | `/api/admin/boletins` | `boletim:write` | Cria rascunho (body: `title`). |
+| `GET` | `/api/admin/boletins?page=&limit=` | `boletim:write` | Lista paginada (`{ data, pagination }`), mais recentes primeiro. |
+| `GET` | `/api/admin/boletins/:id` | `boletim:write` | Abre para edição (rascunho ou publicado). |
+| `PATCH` | `/api/admin/boletins/:id` | `boletim:write` | Salva content + metadados. |
+| `POST` | `/api/admin/boletins/:id/publish` | `boletim:publish` | Publica (gera slug na 1ª vez). |
+| `POST` | `/api/admin/boletins/:id/unpublish` | `boletim:publish` | Volta a rascunho. |
+| `DELETE` | `/api/admin/boletins/:id` | `boletim:write` | Remove o boletim. |
+| `GET` | `/api/boletins/:slug` | **pública** | Boletim **publicado** por slug (404 se não publicado/inexistente). Alimenta a hidratação React. |
+
+Rotas `/api/admin/boletins` montadas como os demais módulos admin; a pública
+`/api/boletins/:slug` montada fora de `/api/admin`, antes do fallback SPA.
+
+## 7. Renderer compartilhado de blocos
+
+Componente `BulletinRenderer` em `src/components/boletim/` (+ um componente por tipo de bloco)
+que recebe `content: Block[]` e renderiza on-brand (paleta/tipografia do site, `max-w` e
+estilos consistentes com o restante do site):
+
+- `heading` → `<h2>/<h3>` com a tipografia Montserrat.
+- `text` → render do doc TipTap por mapeamento de nós (`@tiptap/html` ou `generateHTML` com o
+  mesmo conjunto de extensões do editor, sanitizado), **não** HTML arbitrário do usuário.
+- `image` → `<img src="/media/:id" alt>` responsivo.
+- `gallery` → grade responsiva de `/media/:id` (mantém identidade visual; autor não mexe em CSS).
+- `video` → embed YouTube responsivo (`aspect-video`), reaproveitando o padrão de embed já
+  usado no site (`src/components/AoVivo.tsx` / `VideoCard.tsx`).
+
+**Usado nos dois lugares:** pré-visualização do editor (US-16) e página pública (US-19).
+
+## 8. Frontend — Editor `/painel/boletins` (US-16)
+
+- **Lista** `src/painel/pages/Boletins.tsx`: `PageHeader` + botão "Novo boletim"; tabela/cards
+  com título, status (`Badge`/`StatusBadge`) e ações (editar, publicar/despublicar, copiar
+  link, excluir); `Pager`. Composição **exclusiva** com o kit de UI (`src/painel/ui/`).
+- **Editor** `src/painel/pages/BoletimEditor.tsx` (rota `/painel/boletins/:id`):
+  - Coluna de blocos com **drag-and-drop** (`@dnd-kit/sortable`) + botão remover por bloco;
+    botão "adicionar bloco" (escolhe tipo e insere na posição).
+  - **Texto:** componente TipTap (`@tiptap/react` + `starter-kit` + `extension-link`) com toolbar.
+  - **Imagem/Galeria:** abrem o **modal-picker** da biblioteca (CA-04 US-17), reaproveitando
+    `GET /api/admin/media` (grade paginada + busca) — Imagem seleciona 1, Galeria seleciona N.
+  - **Metadados:** título, resumo, capa (com sugestão da 1ª imagem).
+  - **Pré-visualização:** usa o `BulletinRenderer`.
+  - **Salvar:** `PATCH`; validação (título + ≥1 bloco) com mensagens claras (CA-07 US-16).
+- **Picker reutilizável:** `src/painel/components/MediaPicker.tsx` (modal sobre a API de mídia),
+  usado pelo bloco de Imagem e pelo de Galeria.
+- Item novo no menu lateral (`src/painel/nav-config.tsx`, `perm: 'boletim:write'`); rota no
+  `App.tsx` dentro de `<ProtectedRoute><PainelLayout/></ProtectedRoute>` com `RequirePermission`.
+- Cliente HTTP via `src/painel/admin-api.ts` (CSRF + cookies). Novo `src/painel/boletim-api.ts`.
+
+## 9. Frontend — Página pública + Open Graph (US-19)
+
+- **Rota React** `/boletins/:slug` no `App.tsx` (fora do `/painel`, sem autenticação); página
+  `src/pages/BoletimPublico.tsx` busca `GET /api/boletins/:slug`, mostra `Spinner` no fetch,
+  renderiza com `BulletinRenderer`; 404 amigável se indisponível (CA-04 US-19).
+- **Copiar link** (CA-05) e **Compartilhar no WhatsApp** (CA-06, `https://wa.me/?text=`) no
+  painel (na lista/editor), com confirmação visual ("Link copiado!").
+- **Open Graph server-side (CA-02/03 US-19):** em `server/index.ts`, **antes** do fallback SPA,
+  uma rota `GET /boletins/:slug` busca o boletim **publicado**, lê o `index.html` do disco e
+  injeta no `<head>`: `og:title` (título), `og:description` (resumo), `og:image` (capa em URL
+  **absoluta** `/media/:id`), `og:url`, `og:type=article` (e equivalentes Twitter). Boletim não
+  publicado/inexistente → responde a SPA normal que renderiza o 404 (sem vazar conteúdo).
+  - **Limitação conhecida:** a injeção OG roda no fluxo de **produção** (onde o Express serve o
+    `index.html`); em **dev** o Vite serve o HTML e as tags não são injetadas. A validação do
+    preview do WhatsApp é feita em produção/preview. Documentado na verificação manual.
+- **URL absoluta:** base configurável por env **`PUBLIC_BASE_URL`** (ex.: `https://iasdtucuruvi…`)
+  para compor `og:url`/`og:image` absolutos.
+
+## 10. Permissões e dependências
+
+- **Permissão nova:** adicionar `boletim:publish` ("Publicar/despublicar boletins") ao
+  `server/seed/permissions.catalog.ts`. `boletim:write` **já existe**. O seed
+  (`linkAllPermissions`) religa ambas ao `admin` no próximo boot.
+- **Frontend (novas deps):** `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-link`,
+  `@tiptap/html` (render do doc) e `@dnd-kit/core` + `@dnd-kit/sortable`.
+- **Backend:** sem dependências novas (slugify nativo; JSONB no Postgres).
+- **Env nova:** `PUBLIC_BASE_URL` (URL pública absoluta para OG). `deploy.sh`/compose
+  documentam o valor de produção.
+
+## 11. Segurança
+
+- Guards `boletim:write` / `boletim:publish` em todas as rotas admin; rota pública só serve
+  `status='published'`.
+- **Texto rico sem HTML cru do usuário:** TipTap doc renderizado por mapeamento de nós
+  conhecidos; links com `rel="noopener nofollow"` e protocolo validado (sem `javascript:`).
+- **Vídeo:** apenas `youtubeId` extraído/validado é persistido; embed monta a URL canônica do
+  YouTube (sem aceitar iframe/URL arbitrária).
+- **Imagem/Galeria:** referência por `mediaId` (uuid) validado contra a tabela `media`.
+- **OG:** valores escapados ao injetar no HTML (evita quebra de atributo/markup).
+
+## 12. Verificação manual (sem suíte de testes — convenção do projeto)
+
+US-16:
+- Criar boletim com título → nasce rascunho; adicionar blocos de cada tipo.
+- Texto com negrito/itálico/lista/link salva e reabre com a formatação intacta.
+- Imagem/Galeria via picker da biblioteca; capa sugerida pela 1ª imagem quando vazia.
+- Vídeo: link válido incorpora; link inválido é recusado com mensagem.
+- Reordenar (drag-and-drop) e remover refletem na pré-visualização e no salvo.
+- Salvar, fechar e reabrir → conteúdo preservado. Salvar sem título/bloco → validação.
+
+US-18:
+- Publicar gera slug legível, sem acento/inválidos; 2º boletim de mesmo título → sufixo `-N`.
+- Editar título de publicado **não** muda o slug. Despublicar → link público fica indisponível.
+- Publicar incompleto (sem título/conteúdo/metadados mínimos) é bloqueado com indicação.
+- Usuário sem `boletim:publish` não publica.
+
+US-19 (em produção/preview):
+- `/boletins/:slug` renderiza todos os tipos de bloco, responsivo e on-brand.
+- Colar o link no WhatsApp mostra cartão com título, resumo e capa; meta tags OG presentes no
+  HTML servido (testar com `curl`/validador de OG, JS desligado).
+- Rascunho/despublicado → página de indisponível (404), sem vazar conteúdo.
+- "Copiar link" copia a URL e confirma; "Compartilhar no WhatsApp" abre com o link.
+
+US-17 (itens fechados aqui):
+- Picker da biblioteca seleciona imagem(ns) existentes no editor.
+- Excluir imagem **em uso** por um boletim é bloqueado com aviso; imagem livre é removida.
+
+## 13. Definição de pronto
+
+US-16:
+- [ ] Adicionar, editar, reordenar (drag-and-drop) e remover blocos (Título, Texto, Imagem, Galeria, Vídeo).
+- [ ] Galeria em grade responsiva; Vídeo do YouTube incorporado; Texto rico (TipTap).
+- [ ] Resumo e capa salvos (capa sugerida pela 1ª imagem).
+- [ ] Conteúdo persistido como JSON e recuperável para reedição; validação de título/blocos.
+- [ ] Permissão `boletim:write` exigida.
+
+US-18:
+- [ ] Slug do título, sem acento/inválidos, único (sufixo incremental).
+- [ ] Publicar/despublicar com transição de estado e `published_at`; slug estável após publicado.
+- [ ] Publicação incompleta bloqueada; permissão `boletim:publish` exigida.
+
+US-19:
+- [ ] Página pública renderizando os blocos, responsiva e on-brand (renderer compartilhado).
+- [ ] Meta tags Open Graph servidas no HTML inicial (validadas no preview do WhatsApp em prod).
+- [ ] Rascunhos/despublicados não acessíveis publicamente (404).
+- [ ] Botão "Copiar link" com confirmação (e compartilhar no WhatsApp).
+
+US-17 (itens adiados, fechados aqui):
+- [ ] Modal-picker da biblioteca no editor (CA-04).
+- [ ] Bloqueio de remoção de imagem em uso por boletim (CA-05), via usage checker registrado.

--- a/docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md
+++ b/docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md
@@ -80,7 +80,7 @@ Tabela `boletins`:
 | `id` | `uuid` PK (`gen_random_uuid()`) | |
 | `title` | `text` not null | título; base do slug |
 | `summary` | `text` null | resumo (CA-05 US-16 / `og:description`) |
-| `cover_media_id` | `uuid` FK → `media(id)` `ON DELETE SET NULL` | capa (CA-05 US-16 / `og:image`) |
+| `cover_media_id` | `uuid` FK → `media(id)` `ON DELETE SET NULL` | capa (CA-05 US-16 / `og:image`). FK `SET NULL` é defensivo: o usage checker (§6) já bloqueia excluir capa em uso, então a deleção normal não dispara o `SET NULL`. |
 | `content` | `jsonb` not null default `'[]'::jsonb` | sequência ordenada de blocos |
 | `status` | `text` not null default `'draft'` | `draft` \| `published` (CHECK) |
 | `slug` | `text` null | setado na 1ª publicação; **único quando não nulo** |
@@ -122,7 +122,7 @@ montada no composition root `server/container.ts`.
 
 | Arquivo | Responsabilidade |
 |---|---|
-| `boletins.routes.ts` | Liga rotas → controller; aplica `requireAuth` + `requirePermission('boletim:write'\|'boletim:publish')`. Rota pública separada sem guard. |
+| `boletins.routes.ts` | Liga rotas → controller; aplica `requireAuth` + `requirePermission('boletim:write'\|'boletim:publish')`. **Toda rota mutante** (POST/PATCH/DELETE/publish/unpublish) também aplica `requireCsrf` (`../auth/middleware/require-csrf.js`), como em `media.routes.ts`/`user.routes.ts`. Rota pública (`GET`) separada sem guard. |
 | `boletins.controller.ts` | HTTP fino: valida DTO, chama service, monta resposta. Sem regra de negócio. |
 | `boletins.service.ts` | Regra: validação de conteúdo, geração de slug + unicidade, transições de estado (publish/unpublish), sugestão de capa (1ª imagem se vazia). Não conhece `req`/`res` nem SQL. |
 | `boletins.repository.ts` | Único ponto com SQL de `boletins` (create, get by id, get published by slug, list paginada, update content/metadata, set status/slug/published_at, delete, **checar uso de um mediaId**). |
@@ -146,8 +146,13 @@ montada no composition root `server/container.ts`.
 - **Slug estável:** editar o título depois **não** altera o slug. (CA-04 US-18)
 
 **Usage checker de mídia (fecha CA-05 US-17):** `boletins.usage.ts` expõe um checker que
-consulta se um `mediaId` aparece como `cover_media_id`, ou dentro de `content` em bloco
-`image`/`gallery` de **qualquer** boletim (consulta JSONB no repositório). Registrado no array
+consulta se um `mediaId` aparece, em **qualquer** boletim (rascunho ou publicado), como:
+(a) `cover_media_id`; (b) `props.mediaId` de um bloco `image`; ou (c) membro de `props.mediaIds`
+de um bloco `gallery`. A consulta JSONB precisa cobrir as **duas formas** do schema (§5):
+bloco `image` guarda `mediaId` singular e `gallery` guarda `mediaIds` array — uma única
+expressão `content @> '[{"type":"image",...}]'` **não** pega a galeria. A query expande os
+blocos (`jsonb_array_elements(content)`) e testa `elem->'props'->>'mediaId' = $1` **ou**
+`elem->'props'->'mediaIds' ? $1`, em `OR` com `cover_media_id = $1`. Registrado no array
 `usageCheckers` do `MediaService` no `container.ts` (hoje `[]`). Resultado: excluir imagem em
 uso passa a lançar `ConflictError` **sem alterar o módulo de mídia**.
 
@@ -164,8 +169,20 @@ uso passa a lançar `ConflictError` **sem alterar o módulo de mídia**.
 | `DELETE` | `/api/admin/boletins/:id` | `boletim:write` | Remove o boletim. |
 | `GET` | `/api/boletins/:slug` | **pública** | Boletim **publicado** por slug (404 se não publicado/inexistente). Alimenta a hidratação React. |
 
-Rotas `/api/admin/boletins` montadas como os demais módulos admin; a pública
-`/api/boletins/:slug` montada fora de `/api/admin`, antes do fallback SPA.
+Todas as rotas mutantes acima carregam `requireCsrf` além de `requireAuth`+`requirePermission`
+(convenção do projeto — ver `media.routes.ts`). Rotas `/api/admin/boletins` montadas como os
+demais módulos admin; a pública `/api/boletins/:slug` montada fora de `/api/admin`, antes do
+fallback SPA, **sem** CSRF.
+
+**Geração de slug e corrida (CA-02 US-18):** a unicidade é garantida em última instância pelo
+índice único parcial (§4). O service tenta `slugify(title)`, depois sufixos `-2`, `-3`… com base
+nos slugs existentes; o `INSERT/UPDATE` de publicação é envolvido em retry que captura a
+violação de unicidade do Postgres (`23505`) e regenera o próximo sufixo — o banco é a fonte da
+verdade, evitando colisão entre publicações concorrentes de títulos iguais.
+
+**Bloqueio de publicação incompleta (CA-06 US-18 / CA-07 US-16):** o `BadRequestError` carrega
+um `details` enumerando os campos faltantes (`title`, `content`, `summary`/`cover`), no formato
+`{ error, details }` do error-handler central, para o editor exibir mensagens por campo.
 
 ## 7. Renderer compartilhado de blocos
 
@@ -181,7 +198,10 @@ estilos consistentes com o restante do site):
 - `video` → embed YouTube responsivo (`aspect-video`), reaproveitando o padrão de embed já
   usado no site (`src/components/AoVivo.tsx` / `VideoCard.tsx`).
 
-**Usado nos dois lugares:** pré-visualização do editor (US-16) e página pública (US-19).
+**Usado nos dois lugares:** pré-visualização do editor (US-16) e página pública (US-19). O
+`BulletinRenderer` (e o `generateHTML`/`@tiptap/html` do bloco de texto) é **client-only** —
+roda no bundle React, nunca importado em `server/`. O caminho de OG injeta apenas o `<head>`; o
+corpo do boletim é hidratado no cliente, então o TipTap não entra no backend.
 
 ## 8. Frontend — Editor `/painel/boletins` (US-16)
 
@@ -210,14 +230,22 @@ estilos consistentes com o restante do site):
   renderiza com `BulletinRenderer`; 404 amigável se indisponível (CA-04 US-19).
 - **Copiar link** (CA-05) e **Compartilhar no WhatsApp** (CA-06, `https://wa.me/?text=`) no
   painel (na lista/editor), com confirmação visual ("Link copiado!").
-- **Open Graph server-side (CA-02/03 US-19):** em `server/index.ts`, **antes** do fallback SPA,
-  uma rota `GET /boletins/:slug` busca o boletim **publicado**, lê o `index.html` do disco e
-  injeta no `<head>`: `og:title` (título), `og:description` (resumo), `og:image` (capa em URL
-  **absoluta** `/media/:id`), `og:url`, `og:type=article` (e equivalentes Twitter). Boletim não
-  publicado/inexistente → responde a SPA normal que renderiza o 404 (sem vazar conteúdo).
-  - **Limitação conhecida:** a injeção OG roda no fluxo de **produção** (onde o Express serve o
-    `index.html`); em **dev** o Vite serve o HTML e as tags não são injetadas. A validação do
-    preview do WhatsApp é feita em produção/preview. Documentado na verificação manual.
+- **Slug "avisado" (CA-04 US-18):** após publicado, o slug fica travado; o editor exibe o slug
+  com um indicador de que ele está bloqueado (não muda ao editar o título). **Alteração
+  explícita de slug fica fora deste sub-projeto** (adiada para a US-20/gestão); aqui só
+  informamos o admin de que o link é estável.
+- **Open Graph server-side (CA-02/03 US-19):** uma rota `GET /boletins/:slug` é registrada
+  **dentro do bloco `if (process.env.NODE_ENV === 'production')`** de `server/index.ts` (hoje
+  ~linha 106, onde ficam `express.static(dist)` e o catch-all `{*path}`), **antes** do
+  `app.get('{*path}', …)`. Ela busca o boletim **publicado**, lê o **`dist/index.html`** (o HTML
+  já construído, com os hashes dos assets — não o `index.html` da raiz, que é o template Vite),
+  injeta no `<head>` `og:title` (título), `og:description` (resumo), `og:image` (capa em URL
+  **absoluta**), `og:url`, `og:type=article` (+ equivalentes Twitter), e devolve o HTML. Boletim
+  não publicado/inexistente → cai no catch-all SPA normal, que renderiza o 404 (sem vazar
+  conteúdo). Os valores são **escapados** ao injetar (evita quebra de atributo/markup).
+  - **Limitação conhecida:** a injeção OG só roda no fluxo de **produção** (onde o Express serve
+    `dist/index.html`); em **dev** o Vite serve o HTML e as tags não são injetadas. A validação
+    do preview do WhatsApp é feita em produção/preview. Documentado na verificação manual.
 - **URL absoluta:** base configurável por env **`PUBLIC_BASE_URL`** (ex.: `https://iasdtucuruvi…`)
   para compor `og:url`/`og:image` absolutos.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,15 @@
       "name": "iasd-tucuruvi",
       "version": "0.2.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
+        "@tiptap/extension-link": "^2.27.2",
+        "@tiptap/html": "^2.27.2",
+        "@tiptap/pm": "^2.27.2",
+        "@tiptap/react": "^2.27.2",
+        "@tiptap/starter-kit": "^2.27.2",
         "aos": "^2.3.4",
         "argon2": "^0.44.0",
         "cookie-parser": "^1.4.7",
@@ -589,6 +597,59 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -2102,6 +2163,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2492,6 +2569,425 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@tiptap/core": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.27.2.tgz",
+      "integrity": "sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.27.2.tgz",
+      "integrity": "sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.2.tgz",
+      "integrity": "sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/html": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.27.2.tgz",
+      "integrity": "sha512-WiZgAvFjUprjyAczxAHLN9k++w7klwsCJ7EJDljtW/QXQ476Q0GqNtaHG4WRuW25cBH7c7AWZFptALeak2OE4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "zeed-dom": "^0.15.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.23.0",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.27.2.tgz",
+      "integrity": "sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-floating-menu": "^2.27.2",
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-deep-equal": "^3",
+        "use-sync-external-store": "^1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2673,6 +3169,28 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
     "node_modules/@types/multer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
@@ -2783,6 +3301,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3945,6 +4469,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -3974,6 +4504,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -4141,6 +4683,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4375,6 +4929,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -5800,6 +6360,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5900,6 +6485,39 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5908,6 +6526,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -6316,6 +6940,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -6849,6 +7479,213 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz",
+      "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.9.tgz",
+      "integrity": "sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6860,6 +7697,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
@@ -7217,6 +8063,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -7996,6 +8848,15 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8115,8 +8976,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -8194,6 +9054,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -8289,6 +9155,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -8880,6 +9755,12 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -9138,6 +10019,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeed-dom": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.15.1.tgz",
+      "integrity": "sha512-dtZ0aQSFyZmoJS0m06/xBN1SazUBPL5HpzlAcs/KcRW0rzadYw12deQBjeMhGKMMeGEp7bA9vmikMLaO4exBcg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-what": "^6.1.0",
+        "entities": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/holtwick"
+      }
+    },
+    "node_modules/zeed-dom/node_modules/entities": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
+      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
+    "@tiptap/extension-link": "^2.27.2",
+    "@tiptap/html": "^2.27.2",
+    "@tiptap/pm": "^2.27.2",
+    "@tiptap/react": "^2.27.2",
+    "@tiptap/starter-kit": "^2.27.2",
     "aos": "^2.3.4",
     "argon2": "^0.44.0",
     "cookie-parser": "^1.4.7",

--- a/server/container.ts
+++ b/server/container.ts
@@ -34,6 +34,11 @@ import { MediaRepository } from './modules/media/media.repository.js'
 import { MediaService } from './modules/media/media.service.js'
 import { MediaController } from './modules/media/media.controller.js'
 import { makeMediaAdminRoutes, makeMediaPublicRoutes } from './modules/media/media.routes.js'
+import { BoletinsRepository } from './modules/boletins/boletins.repository.js'
+import { BoletinsService } from './modules/boletins/boletins.service.js'
+import { BoletinsController } from './modules/boletins/boletins.controller.js'
+import { makeBoletinsAdminRoutes, makeBoletinsPublicRoutes } from './modules/boletins/boletins.routes.js'
+import { makeBoletinMediaUsageChecker } from './modules/boletins/boletins.usage.js'
 
 const tokens = new TokenService(config.jwtAccessSecret, config.jwtAccessTtl)
 const userRepo = new UserRepository(pool)
@@ -75,9 +80,18 @@ const settingsController = new SettingsController(settingsService)
 
 export const settingsRoutes = makeSettingsRoutes(settingsController, requireAuth, requirePermission)
 
+// --- Boletim (US-16/18/19) ---
+// Criado antes da mídia: o usage checker do boletim entra na construção do MediaService.
+const boletinsRepo = new BoletinsRepository(pool)
+const boletinsService = new BoletinsService(boletinsRepo, config.publicBaseUrl)
+const boletinsController = new BoletinsController(boletinsService)
+export const boletinsAdminRoutes = makeBoletinsAdminRoutes(boletinsController, requireAuth, requirePermission)
+export const boletinsPublicRoutes = makeBoletinsPublicRoutes(boletinsController)
+export { boletinsService }
+
 // --- Biblioteca de mídia (US-17) ---
 const mediaRepo = new MediaRepository(pool)
-const mediaService = new MediaService(mediaRepo, []) // usage checkers: vazio por ora (editor pluga depois)
+const mediaService = new MediaService(mediaRepo, [makeBoletinMediaUsageChecker(boletinsRepo)])
 const mediaController = new MediaController(mediaService)
 
 export const mediaAdminRoutes = makeMediaAdminRoutes(mediaController, requireAuth, requirePermission)

--- a/server/core/config.ts
+++ b/server/core/config.ts
@@ -32,6 +32,8 @@ export const config = {
 
   cookieSecure: process.env.COOKIE_SECURE === 'true',
   appBaseUrl: process.env.APP_BASE_URL || 'http://localhost:5173',
+  // URL pública absoluta do site (para publicUrl do boletim e Open Graph). Vazia em dev → URL relativa.
+  publicBaseUrl: process.env.PUBLIC_BASE_URL ?? '',
 
   passwordResetTtlMin: int('PASSWORD_RESET_TTL_MIN', 30),
   invitationTtlDays: int('INVITE_TTL_DAYS', 7),

--- a/server/core/error-handler.ts
+++ b/server/core/error-handler.ts
@@ -1,11 +1,15 @@
 // server/core/error-handler.ts
 import type { ErrorRequestHandler } from 'express'
 import { ZodError } from 'zod'
-import { AppError, ValidationError } from './errors.js'
+import { AppError, BadRequestError, ValidationError } from './errors.js'
 
 export const errorHandler: ErrorRequestHandler = (err, _req, res, _next) => {
   if (err instanceof ValidationError) {
     res.status(422).json({ error: err.message, details: err.details })
+    return
+  }
+  if (err instanceof BadRequestError) {
+    res.status(400).json({ error: err.message, details: err.details })
     return
   }
   if (err instanceof ZodError) {

--- a/server/core/errors.ts
+++ b/server/core/errors.ts
@@ -8,7 +8,10 @@ export abstract class AppError extends Error {
   }
 }
 
-export class BadRequestError extends AppError { readonly status = 400 }
+export class BadRequestError extends AppError {
+  readonly status = 400
+  constructor(message: string, readonly details?: unknown) { super(message) }
+}
 export class UnauthorizedError extends AppError { readonly status = 401 }
 export class ForbiddenError extends AppError { readonly status = 403 }
 export class NotFoundError extends AppError { readonly status = 404 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,10 +8,12 @@ import { sendContatoEmail } from './lib/mail.js'
 import { fetchFlickrFeed } from './lib/flickr.js'
 import { fetchYouTubePlaylist } from './lib/youtube.js'
 import cookieParser from 'cookie-parser'
+import { readFileSync } from 'fs'
 import {
   authRoutes, roleRoutes, invitationAdminRoutes, invitationPublicRoutes, settingsRoutes, userRoutes, bootstrap,
-  mediaAdminRoutes, mediaPublicRoutes, boletinsAdminRoutes, boletinsPublicRoutes,
+  mediaAdminRoutes, mediaPublicRoutes, boletinsAdminRoutes, boletinsPublicRoutes, boletinsService,
 } from './container.js'
+import { injectOgTags } from './lib/og.js'
 import { errorHandler } from './core/error-handler.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -108,6 +110,29 @@ app.use('/api/boletins', boletinsPublicRoutes)
 if (process.env.NODE_ENV === 'production') {
   const distPath = path.resolve(__dirname, '..', 'dist')
   app.use(express.static(distPath))
+
+  // SSR só do <head>: injeta Open Graph no HTML do boletim publicado, antes do fallback SPA,
+  // para o preview do WhatsApp (US-19). Boletim inexistente/rascunho cai no catch-all (404 no React).
+  app.get('/boletins/:slug', async (req, res, next) => {
+    try {
+      const boletim = await boletinsService.getPublishedBySlug(String(req.params.slug))
+      if (!boletim) return next()
+      const html = readFileSync(path.join(distPath, 'index.html'), 'utf8')
+      const base = process.env.PUBLIC_BASE_URL ?? ''
+      const cover = boletim.coverMediaId
+        ? `${base}/media/${boletim.coverMediaId}`
+        : `${base}/img/logo-iasd.png`
+      res.send(injectOgTags(html, {
+        title: boletim.title,
+        description: boletim.summary ?? '',
+        image: cover,
+        url: `${base}/boletins/${boletim.slug}`,
+      }))
+    } catch (err) {
+      next(err)
+    }
+  })
+
   app.get('{*path}', (_req, res) => {
     res.sendFile(path.join(distPath, 'index.html'))
   })

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,7 +10,7 @@ import { fetchYouTubePlaylist } from './lib/youtube.js'
 import cookieParser from 'cookie-parser'
 import {
   authRoutes, roleRoutes, invitationAdminRoutes, invitationPublicRoutes, settingsRoutes, userRoutes, bootstrap,
-  mediaAdminRoutes, mediaPublicRoutes,
+  mediaAdminRoutes, mediaPublicRoutes, boletinsAdminRoutes, boletinsPublicRoutes,
 } from './container.js'
 import { errorHandler } from './core/error-handler.js'
 
@@ -98,8 +98,10 @@ app.use('/api/admin', roleRoutes)
 app.use('/api/admin', settingsRoutes)
 app.use('/api/admin', userRoutes)
 app.use('/api/admin', mediaAdminRoutes)
+app.use('/api/admin', boletinsAdminRoutes)
 
 app.use('/media', mediaPublicRoutes)
+app.use('/api/boletins', boletinsPublicRoutes)
 
 // --- Static files (production) ---
 

--- a/server/lib/og.ts
+++ b/server/lib/og.ts
@@ -1,0 +1,42 @@
+/** Escapa valores para inserção segura em atributos HTML (evita quebra de markup). */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export interface OgMeta {
+  title: string
+  description: string
+  image: string
+  url: string
+}
+
+/**
+ * Injeta as meta tags Open Graph (+ Twitter) no <head> do HTML servido, para que o robô do
+ * WhatsApp/redes (que não executa JS) leia o cartão de preview já no HTML inicial (US-19).
+ * Valores são escapados. Também substitui o <title> pelo título do boletim.
+ */
+export function injectOgTags(html: string, meta: OgMeta): string {
+  const t = esc(meta.title)
+  const d = esc(meta.description)
+  const img = esc(meta.image)
+  const url = esc(meta.url)
+  const tags = [
+    `<meta property="og:type" content="article" />`,
+    `<meta property="og:title" content="${t}" />`,
+    `<meta property="og:description" content="${d}" />`,
+    `<meta property="og:image" content="${img}" />`,
+    `<meta property="og:url" content="${url}" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${t}" />`,
+    `<meta name="twitter:description" content="${d}" />`,
+    `<meta name="twitter:image" content="${img}" />`,
+  ].join('\n    ')
+
+  return html
+    .replace(/<title>.*?<\/title>/i, `<title>${t}</title>`)
+    .replace('</head>', `    ${tags}\n  </head>`)
+}

--- a/server/lib/og.ts
+++ b/server/lib/og.ts
@@ -37,6 +37,6 @@ export function injectOgTags(html: string, meta: OgMeta): string {
   ].join('\n    ')
 
   return html
-    .replace(/<title>.*?<\/title>/i, `<title>${t}</title>`)
+    .replace(/<title>.*?<\/title>/is, `<title>${t}</title>`)
     .replace('</head>', `    ${tags}\n  </head>`)
 }

--- a/server/migrations/005_boletins.sql
+++ b/server/migrations/005_boletins.sql
@@ -1,0 +1,21 @@
+-- server/migrations/005_boletins.sql
+-- Boletim Informativo: editor de blocos + publicação (US-16/US-18/US-19).
+CREATE TABLE boletins (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title          text NOT NULL,
+  summary        text,
+  cover_media_id uuid REFERENCES media(id) ON DELETE SET NULL,
+  content        jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status         text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published')),
+  slug           text,
+  published_at   timestamptz,
+  created_by     uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Slug único apenas quando preenchido (rascunhos têm slug NULL).
+CREATE UNIQUE INDEX idx_boletins_slug ON boletins (slug) WHERE slug IS NOT NULL;
+-- Listagem pública/admin por estado e data.
+CREATE INDEX idx_boletins_status_published ON boletins (status, published_at DESC);
+CREATE INDEX idx_boletins_created_at ON boletins (created_at DESC);

--- a/server/modules/boletins/boletins.controller.ts
+++ b/server/modules/boletins/boletins.controller.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from 'express'
+import { createBoletimDto, updateBoletimDto, listBoletinsQuery } from './dto/boletim.dto.js'
+import type { BoletinsService } from './boletins.service.js'
+
+export class BoletinsController {
+  constructor(private readonly service: BoletinsService) {}
+
+  create = async (req: Request, res: Response) => {
+    const dto = createBoletimDto.parse(req.body)
+    const created = await this.service.create(dto, req.user!.id)
+    res.status(201).json({ boletim: created })
+  }
+
+  list = async (req: Request, res: Response) => {
+    const params = listBoletinsQuery.parse(req.query)
+    res.json(await this.service.list(params))
+  }
+
+  get = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.getById(String(req.params.id)) })
+  }
+
+  update = async (req: Request, res: Response) => {
+    const dto = updateBoletimDto.parse(req.body)
+    res.json({ boletim: await this.service.update(String(req.params.id), dto) })
+  }
+
+  publish = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.publish(String(req.params.id)) })
+  }
+
+  unpublish = async (req: Request, res: Response) => {
+    res.json({ boletim: await this.service.unpublish(String(req.params.id)) })
+  }
+
+  remove = async (req: Request, res: Response) => {
+    await this.service.delete(String(req.params.id))
+    res.status(204).end()
+  }
+
+  // pública
+  getBySlug = async (req: Request, res: Response) => {
+    const boletim = await this.service.getPublishedBySlug(String(req.params.slug))
+    if (!boletim) { res.status(404).json({ error: 'Boletim não encontrado.' }); return }
+    res.json({ boletim })
+  }
+}

--- a/server/modules/boletins/boletins.repository.ts
+++ b/server/modules/boletins/boletins.repository.ts
@@ -1,12 +1,12 @@
 import type { Pool } from 'pg'
-import type { Block } from './dto/block.schema.js'
+import type { Row } from './dto/block.schema.js'
 
 export interface BoletimRow {
   id: string
   title: string
   summary: string | null
   cover_media_id: string | null
-  content: Block[]
+  content: Row[]
   status: 'draft' | 'published'
   slug: string | null
   published_at: Date | null
@@ -19,7 +19,7 @@ export interface UpdateBoletimFields {
   title?: string
   summary?: string | null
   coverMediaId?: string | null
-  content?: Block[]
+  content?: Row[]
 }
 
 export class BoletinsRepository {
@@ -102,19 +102,24 @@ export class BoletinsRepository {
    * True se a mídia está em uso por QUALQUER boletim: como capa, ou dentro de content
    * em bloco image (props.mediaId) ou gallery (props.mediaIds[]). Fecha CA-05 da US-17.
    *
-   * Cobre apenas referências por id nos blocos image/gallery — que são os ÚNICOS que
-   * referenciam a biblioteca. O bloco `text` guarda um doc do TipTap montado só com
-   * StarterKit + Link (sem nó de imagem), então nunca carrega `mediaId`; se um dia o
-   * editor ganhar imagem inline no texto, esta query precisa varrer `props.doc` também.
+   * O conteúdo é aninhado em linhas → colunas → blocos; a query faz cross-join lateral
+   * sobre os arrays JSONB (content → r.columns → c.blocks) e testa cada bloco. Cobre apenas
+   * referências por id nos blocos image/gallery — que são os ÚNICOS que referenciam a
+   * biblioteca. O bloco `text` guarda um doc do TipTap montado só com StarterKit + Link
+   * (sem nó de imagem), então nunca carrega `mediaId`; se um dia o editor ganhar imagem
+   * inline no texto, esta query precisa varrer `props.doc` também.
    */
   async mediaInUse(mediaId: string): Promise<boolean> {
     const r = await this.pool.query(
       `SELECT 1 FROM boletins b
        WHERE b.cover_media_id = $1
           OR EXISTS (
-            SELECT 1 FROM jsonb_array_elements(b.content) AS elem
-            WHERE elem->'props'->>'mediaId' = $1
-               OR elem->'props'->'mediaIds' ? $1
+            SELECT 1
+            FROM jsonb_array_elements(b.content) AS r,
+                 jsonb_array_elements(r->'columns') AS c,
+                 jsonb_array_elements(c->'blocks') AS blk
+            WHERE blk->'props'->>'mediaId' = $1
+               OR blk->'props'->'mediaIds' ? $1
           )
        LIMIT 1`, [mediaId],
     )

--- a/server/modules/boletins/boletins.repository.ts
+++ b/server/modules/boletins/boletins.repository.ts
@@ -1,0 +1,118 @@
+import type { Pool } from 'pg'
+import type { Block } from './dto/block.schema.js'
+
+export interface BoletimRow {
+  id: string
+  title: string
+  summary: string | null
+  cover_media_id: string | null
+  content: Block[]
+  status: 'draft' | 'published'
+  slug: string | null
+  published_at: Date | null
+  created_by: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+export interface UpdateBoletimFields {
+  title?: string
+  summary?: string | null
+  coverMediaId?: string | null
+  content?: Block[]
+}
+
+export class BoletinsRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(title: string, createdBy: string): Promise<BoletimRow> {
+    const r = await this.pool.query<BoletimRow>(
+      `INSERT INTO boletins (title, created_by) VALUES ($1, $2) RETURNING *`,
+      [title, createdBy],
+    )
+    return r.rows[0]
+  }
+
+  async findById(id: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>('SELECT * FROM boletins WHERE id = $1', [id])
+    return r.rows[0] ?? null
+  }
+
+  async findPublishedBySlug(slug: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `SELECT * FROM boletins WHERE slug = $1 AND status = 'published'`, [slug],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async list({ limit, offset }: { limit: number; offset: number }): Promise<{ rows: BoletimRow[]; total: number }> {
+    const rows = await this.pool.query<BoletimRow>(
+      `SELECT * FROM boletins ORDER BY created_at DESC LIMIT $1 OFFSET $2`, [limit, offset],
+    )
+    const count = await this.pool.query<{ count: number }>('SELECT count(*)::int AS count FROM boletins')
+    return { rows: rows.rows, total: count.rows[0].count }
+  }
+
+  /** Atualiza somente os campos fornecidos; sempre toca updated_at. */
+  async update(id: string, f: UpdateBoletimFields): Promise<BoletimRow | null> {
+    const sets: string[] = []
+    const vals: unknown[] = []
+    let i = 1
+    if (f.title !== undefined) { sets.push(`title = $${i++}`); vals.push(f.title) }
+    if (f.summary !== undefined) { sets.push(`summary = $${i++}`); vals.push(f.summary) }
+    if (f.coverMediaId !== undefined) { sets.push(`cover_media_id = $${i++}`); vals.push(f.coverMediaId) }
+    if (f.content !== undefined) { sets.push(`content = $${i++}::jsonb`); vals.push(JSON.stringify(f.content)) }
+    sets.push(`updated_at = now()`)
+    vals.push(id)
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET ${sets.join(', ')} WHERE id = $${i} RETURNING *`, vals,
+    )
+    return r.rows[0] ?? null
+  }
+
+  async setPublished(id: string, slug: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET status = 'published', slug = $1, published_at = now(), updated_at = now()
+       WHERE id = $2 RETURNING *`, [slug, id],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async setUnpublished(id: string): Promise<BoletimRow | null> {
+    const r = await this.pool.query<BoletimRow>(
+      `UPDATE boletins SET status = 'draft', updated_at = now() WHERE id = $1 RETURNING *`, [id],
+    )
+    return r.rows[0] ?? null
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM boletins WHERE id = $1', [id])
+  }
+
+  /** True se já existe um boletim usando este slug (qualquer estado). */
+  async slugExists(slug: string): Promise<boolean> {
+    const r = await this.pool.query('SELECT 1 FROM boletins WHERE slug = $1 LIMIT 1', [slug])
+    return r.rowCount! > 0
+  }
+
+  /**
+   * True se a mídia está em uso por QUALQUER boletim: como capa, ou dentro de content
+   * em bloco image (props.mediaId) ou gallery (props.mediaIds[]). Fecha CA-05 da US-17.
+   */
+  async mediaInUse(mediaId: string): Promise<boolean> {
+    const r = await this.pool.query(
+      `SELECT 1 FROM boletins b
+       WHERE b.cover_media_id = $1
+          OR EXISTS (
+            SELECT 1 FROM jsonb_array_elements(b.content) AS elem
+            WHERE elem->'props'->>'mediaId' = $1
+               OR elem->'props'->'mediaIds' ? $1
+          )
+       LIMIT 1`, [mediaId],
+    )
+    // Nota: `content` é NOT NULL DEFAULT '[]' e o repo só escreve arrays, então
+    // jsonb_array_elements é seguro. O operador `?` testa pertinência de string no array
+    // (gallery) e o `->>` compara a string (image). `$1` é placeholder pg, sem conflito com `?`.
+    return r.rowCount! > 0
+  }
+}

--- a/server/modules/boletins/boletins.repository.ts
+++ b/server/modules/boletins/boletins.repository.ts
@@ -79,6 +79,9 @@ export class BoletinsRepository {
   }
 
   async setUnpublished(id: string): Promise<BoletimRow | null> {
+    // O `slug` é deliberadamente MANTIDO ao despublicar: preserva o link já distribuído
+    // (CA-04 US-18) e faz o `publish` reusar o mesmo slug ao republicar (slug imutável).
+    // Não limpar o slug aqui — a rota pública já esconde o conteúdo via status='published'.
     const r = await this.pool.query<BoletimRow>(
       `UPDATE boletins SET status = 'draft', updated_at = now() WHERE id = $1 RETURNING *`, [id],
     )
@@ -98,6 +101,11 @@ export class BoletinsRepository {
   /**
    * True se a mídia está em uso por QUALQUER boletim: como capa, ou dentro de content
    * em bloco image (props.mediaId) ou gallery (props.mediaIds[]). Fecha CA-05 da US-17.
+   *
+   * Cobre apenas referências por id nos blocos image/gallery — que são os ÚNICOS que
+   * referenciam a biblioteca. O bloco `text` guarda um doc do TipTap montado só com
+   * StarterKit + Link (sem nó de imagem), então nunca carrega `mediaId`; se um dia o
+   * editor ganhar imagem inline no texto, esta query precisa varrer `props.doc` também.
    */
   async mediaInUse(mediaId: string): Promise<boolean> {
     const r = await this.pool.query(

--- a/server/modules/boletins/boletins.routes.ts
+++ b/server/modules/boletins/boletins.routes.ts
@@ -1,0 +1,32 @@
+import { Router, type RequestHandler } from 'express'
+import { requireCsrf } from '../auth/middleware/require-csrf.js'
+import type { BoletinsController } from './boletins.controller.js'
+
+const wrap = (h: RequestHandler): RequestHandler => (req, res, next) =>
+  Promise.resolve(h(req, res, next)).catch(next)
+
+/** Montado em /api/admin. */
+export function makeBoletinsAdminRoutes(
+  c: BoletinsController,
+  requireAuth: RequestHandler,
+  requirePermission: (key: string) => RequestHandler,
+): Router {
+  const r = Router()
+  const write = requirePermission('boletim:write')
+  const publish = requirePermission('boletim:publish')
+  r.get('/boletins', wrap(requireAuth), write, wrap(c.list))
+  r.post('/boletins', wrap(requireAuth), write, requireCsrf, wrap(c.create))
+  r.get('/boletins/:id', wrap(requireAuth), write, wrap(c.get))
+  r.patch('/boletins/:id', wrap(requireAuth), write, requireCsrf, wrap(c.update))
+  r.post('/boletins/:id/publish', wrap(requireAuth), publish, requireCsrf, wrap(c.publish))
+  r.post('/boletins/:id/unpublish', wrap(requireAuth), publish, requireCsrf, wrap(c.unpublish))
+  r.delete('/boletins/:id', wrap(requireAuth), write, requireCsrf, wrap(c.remove))
+  return r
+}
+
+/** Montado em /api/boletins (pública, sem auth/CSRF). */
+export function makeBoletinsPublicRoutes(c: BoletinsController): Router {
+  const r = Router()
+  r.get('/:slug', wrap(c.getBySlug))
+  return r
+}

--- a/server/modules/boletins/boletins.service.ts
+++ b/server/modules/boletins/boletins.service.ts
@@ -59,7 +59,7 @@ export class BoletinsService {
 
   async list(params: ListBoletinsQuery): Promise<Paginated<BoletimDTO>> {
     const { rows, total } = await this.repo.list({ limit: params.limit, offset: toOffset(params) })
-    return paginate(rows.map(this.toDTO), total, params)
+    return paginate(rows.map((r) => this.toDTO(r)), total, params)
   }
 
   async update(id: string, dto: UpdateBoletimDto): Promise<BoletimDTO> {

--- a/server/modules/boletins/boletins.service.ts
+++ b/server/modules/boletins/boletins.service.ts
@@ -1,0 +1,144 @@
+import { BadRequestError, NotFoundError } from '../../core/errors.js'
+import { paginate, toOffset, type Paginated } from '../../core/pagination.js'
+import { slugify } from './boletins.slug.js'
+import type { BoletinsRepository, BoletimRow } from './boletins.repository.js'
+import type { Block } from './dto/block.schema.js'
+import type { CreateBoletimDto, UpdateBoletimDto, ListBoletinsQuery } from './dto/boletim.dto.js'
+
+export interface BoletimDTO {
+  id: string
+  title: string
+  summary: string | null
+  coverMediaId: string | null
+  content: Block[]
+  status: 'draft' | 'published'
+  slug: string | null
+  publicUrl: string | null
+  publishedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+const PG_UNIQUE_VIOLATION = '23505'
+
+export class BoletinsService {
+  constructor(
+    private readonly repo: BoletinsRepository,
+    private readonly publicBaseUrl: string,
+  ) {}
+
+  private toDTO = (row: BoletimRow): BoletimDTO => ({
+    id: row.id,
+    title: row.title,
+    summary: row.summary,
+    coverMediaId: row.cover_media_id,
+    content: row.content,
+    status: row.status,
+    slug: row.slug,
+    publicUrl: row.slug && row.status === 'published'
+      ? `${this.publicBaseUrl}/boletins/${row.slug}` : null,
+    publishedAt: row.published_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  })
+
+  async create(dto: CreateBoletimDto, userId: string): Promise<BoletimDTO> {
+    return this.toDTO(await this.repo.create(dto.title, userId))
+  }
+
+  async getById(id: string): Promise<BoletimDTO> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+    return this.toDTO(row)
+  }
+
+  async getPublishedBySlug(slug: string): Promise<BoletimDTO | null> {
+    const row = await this.repo.findPublishedBySlug(slug)
+    return row ? this.toDTO(row) : null
+  }
+
+  async list(params: ListBoletinsQuery): Promise<Paginated<BoletimDTO>> {
+    const { rows, total } = await this.repo.list({ limit: params.limit, offset: toOffset(params) })
+    return paginate(rows.map(this.toDTO), total, params)
+  }
+
+  async update(id: string, dto: UpdateBoletimDto): Promise<BoletimDTO> {
+    const current = await this.repo.findById(id)
+    if (!current) throw new NotFoundError('Boletim não encontrado.')
+
+    // Sugestão de capa: se não há capa (nem atual nem informada) e o conteúdo tem imagem, sugere a 1ª.
+    let coverMediaId = dto.coverMediaId
+    const content = dto.content
+    if (coverMediaId === undefined && !current.cover_media_id && content) {
+      const firstImg = firstImageMediaId(content)
+      if (firstImg) coverMediaId = firstImg
+    }
+
+    const updated = await this.repo.update(id, {
+      title: dto.title,
+      summary: dto.summary,
+      coverMediaId,
+      content,
+    })
+    return this.toDTO(updated!)
+  }
+
+  async publish(id: string): Promise<BoletimDTO> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+
+    // Bloqueio de publicação incompleta (CA-06 US-18): enumera o que falta.
+    const missing: string[] = []
+    if (!row.title?.trim()) missing.push('title')
+    if (!Array.isArray(row.content) || row.content.length === 0) missing.push('content')
+    if (!row.summary?.trim() && !row.cover_media_id) missing.push('summary/cover')
+    if (missing.length) {
+      throw new BadRequestError('Boletim incompleto para publicação.', { missing })
+    }
+
+    // Slug imutável após a 1ª publicação (CA-04 US-18): só gera se ainda não tem.
+    if (row.slug) {
+      return this.toDTO((await this.repo.setPublished(id, row.slug))!)
+    }
+    return this.toDTO(await this.publishWithUniqueSlug(id, row.title))
+  }
+
+  /** Gera slug único; o índice parcial é a fonte da verdade — retry em 23505. */
+  private async publishWithUniqueSlug(id: string, title: string): Promise<BoletimRow> {
+    const base = slugify(title)
+    let candidate = base
+    let n = 1
+    // pré-checagem barata para evitar a maioria das colisões
+    while (await this.repo.slugExists(candidate)) { n++; candidate = `${base}-${n}` }
+    for (;;) {
+      try {
+        return (await this.repo.setPublished(id, candidate))!
+      } catch (err) {
+        if ((err as { code?: string }).code === PG_UNIQUE_VIOLATION) {
+          n++; candidate = `${base}-${n}`; continue
+        }
+        throw err
+      }
+    }
+  }
+
+  async unpublish(id: string): Promise<BoletimDTO> {
+    const updated = await this.repo.setUnpublished(id)
+    if (!updated) throw new NotFoundError('Boletim não encontrado.')
+    return this.toDTO(updated)
+  }
+
+  async delete(id: string): Promise<void> {
+    const row = await this.repo.findById(id)
+    if (!row) throw new NotFoundError('Boletim não encontrado.')
+    await this.repo.delete(id)
+  }
+}
+
+function firstImageMediaId(content: Block[]): string | null {
+  for (const b of content) {
+    if (b.type === 'image') return b.props.mediaId
+    if (b.type === 'gallery' && b.props.mediaIds.length) return b.props.mediaIds[0]
+  }
+  return null
+}

--- a/server/modules/boletins/boletins.service.ts
+++ b/server/modules/boletins/boletins.service.ts
@@ -2,7 +2,7 @@ import { BadRequestError, NotFoundError } from '../../core/errors.js'
 import { paginate, toOffset, type Paginated } from '../../core/pagination.js'
 import { slugify } from './boletins.slug.js'
 import type { BoletinsRepository, BoletimRow } from './boletins.repository.js'
-import type { Block } from './dto/block.schema.js'
+import type { Row } from './dto/block.schema.js'
 import type { CreateBoletimDto, UpdateBoletimDto, ListBoletinsQuery } from './dto/boletim.dto.js'
 
 export interface BoletimDTO {
@@ -10,7 +10,7 @@ export interface BoletimDTO {
   title: string
   summary: string | null
   coverMediaId: string | null
-  content: Block[]
+  content: Row[]
   status: 'draft' | 'published'
   slug: string | null
   publicUrl: string | null
@@ -90,7 +90,7 @@ export class BoletinsService {
     // Bloqueio de publicação incompleta (CA-06 US-18): enumera o que falta.
     const missing: string[] = []
     if (!row.title?.trim()) missing.push('title')
-    if (!Array.isArray(row.content) || row.content.length === 0) missing.push('content')
+    if (contentIsEmpty(row.content)) missing.push('content')
     if (!row.summary?.trim() && !row.cover_media_id) missing.push('summary/cover')
     if (missing.length) {
       throw new BadRequestError('Boletim incompleto para publicação.', { missing })
@@ -135,10 +135,21 @@ export class BoletinsService {
   }
 }
 
-function firstImageMediaId(content: Block[]): string | null {
-  for (const b of content) {
-    if (b.type === 'image') return b.props.mediaId
-    if (b.type === 'gallery' && b.props.mediaIds.length) return b.props.mediaIds[0]
+/** Primeira mídia de imagem/galeria em qualquer bloco, varrendo linhas → colunas → blocos. */
+function firstImageMediaId(content: Row[]): string | null {
+  for (const row of content) {
+    for (const col of row.columns) {
+      for (const b of col.blocks) {
+        if (b.type === 'image') return b.props.mediaId
+        if (b.type === 'gallery' && b.props.mediaIds.length) return b.props.mediaIds[0]
+      }
+    }
   }
   return null
+}
+
+/** Conteúdo "vazio": sem linhas, ou toda coluna de toda linha sem blocos. */
+function contentIsEmpty(content: Row[]): boolean {
+  if (!Array.isArray(content) || content.length === 0) return true
+  return content.every((row) => row.columns.every((col) => col.blocks.length === 0))
 }

--- a/server/modules/boletins/boletins.slug.ts
+++ b/server/modules/boletins/boletins.slug.ts
@@ -1,0 +1,11 @@
+// server/modules/boletins/boletins.slug.ts
+/** Gera um slug legível e seguro para URL a partir de um título (sem acentos/especiais). */
+export function slugify(title: string): string {
+  const base = title
+    .normalize('NFD').replace(/[̀-ͯ]/g, '') // remove diacríticos
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') // não-alfanumérico → hífen
+    .replace(/^-+|-+$/g, '')     // tira hífens das pontas
+    .slice(0, 80)
+  return base || 'boletim'
+}

--- a/server/modules/boletins/boletins.usage.ts
+++ b/server/modules/boletins/boletins.usage.ts
@@ -1,0 +1,7 @@
+import type { MediaUsageChecker } from '../media/media.service.js'
+import type { BoletinsRepository } from './boletins.repository.js'
+
+/** Bloqueia exclusão de imagem usada como capa ou dentro de algum boletim. */
+export function makeBoletinMediaUsageChecker(repo: BoletinsRepository): MediaUsageChecker {
+  return (mediaId: string) => repo.mediaInUse(mediaId)
+}

--- a/server/modules/boletins/dto/block.schema.ts
+++ b/server/modules/boletins/dto/block.schema.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+/** Extrai o videoId de uma URL do YouTube (watch, youtu.be, embed, shorts). */
+export function extractYouTubeId(input: string): string | null {
+  const s = input.trim()
+  // já é um id puro (11 chars base64url)
+  if (/^[a-zA-Z0-9_-]{11}$/.test(s)) return s
+  const patterns = [
+    /[?&]v=([a-zA-Z0-9_-]{11})/,
+    /youtu\.be\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ]
+  for (const p of patterns) {
+    const m = s.match(p)
+    if (m) return m[1]
+  }
+  return null
+}
+
+const youtubeId = z.string().regex(/^[a-zA-Z0-9_-]{11}$/, 'Vídeo do YouTube inválido.')
+
+const headingBlock = z.object({
+  id: z.string(),
+  type: z.literal('heading'),
+  props: z.object({ text: z.string().max(200), level: z.union([z.literal(2), z.literal(3)]) }),
+})
+
+const textBlock = z.object({
+  id: z.string(),
+  type: z.literal('text'),
+  // doc do TipTap/ProseMirror — validação permissiva (objeto). O conteúdo é renderizado
+  // por mapeamento de nós no client, nunca como HTML cru.
+  props: z.object({ doc: z.record(z.string(), z.unknown()) }),
+})
+
+const imageBlock = z.object({
+  id: z.string(),
+  type: z.literal('image'),
+  props: z.object({ mediaId: z.string().uuid(), alt: z.string().max(200).default('') }),
+})
+
+const galleryBlock = z.object({
+  id: z.string(),
+  type: z.literal('gallery'),
+  props: z.object({ mediaIds: z.array(z.string().uuid()).min(1).max(30) }),
+})
+
+const videoBlock = z.object({
+  id: z.string(),
+  type: z.literal('video'),
+  props: z.object({ youtubeId }),
+})
+
+export const blockSchema = z.discriminatedUnion('type', [
+  headingBlock, textBlock, imageBlock, galleryBlock, videoBlock,
+])
+export type Block = z.infer<typeof blockSchema>
+
+export const contentSchema = z.array(blockSchema)

--- a/server/modules/boletins/dto/block.schema.ts
+++ b/server/modules/boletins/dto/block.schema.ts
@@ -57,4 +57,10 @@ export const blockSchema = z.discriminatedUnion('type', [
 ])
 export type Block = z.infer<typeof blockSchema>
 
-export const contentSchema = z.array(blockSchema)
+// Layout em linhas/colunas: o conteúdo é uma lista ordenada de LINHAS; cada linha tem
+// 1..4 COLUNAS; cada coluna guarda uma lista ordenada de BLOCOS (tipos acima, inalterados).
+export const columnSchema = z.object({ id: z.string(), blocks: z.array(blockSchema) })
+export const rowSchema = z.object({ id: z.string(), columns: z.array(columnSchema).min(1).max(4) })
+export const contentSchema = z.array(rowSchema)
+export type Column = z.infer<typeof columnSchema>
+export type Row = z.infer<typeof rowSchema>

--- a/server/modules/boletins/dto/boletim.dto.ts
+++ b/server/modules/boletins/dto/boletim.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+import { paginationQuery } from '../../../core/pagination.js'
+import { contentSchema } from './block.schema.js'
+
+export const createBoletimDto = z.object({
+  title: z.string().trim().min(1, 'Título é obrigatório.').max(200),
+})
+export type CreateBoletimDto = z.infer<typeof createBoletimDto>
+
+export const updateBoletimDto = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  summary: z.string().trim().max(500).nullable().optional(),
+  coverMediaId: z.string().uuid().nullable().optional(),
+  content: contentSchema.optional(),
+})
+export type UpdateBoletimDto = z.infer<typeof updateBoletimDto>
+
+export const listBoletinsQuery = paginationQuery
+export type ListBoletinsQuery = z.infer<typeof listBoletinsQuery>

--- a/server/seed/permissions.catalog.ts
+++ b/server/seed/permissions.catalog.ts
@@ -6,6 +6,7 @@ export const PERMISSIONS: { key: string; description: string }[] = [
   { key: 'users:manage', description: 'Administrar contas (editar, ativar/desativar, desbloquear, redefinir senha)' },
   { key: 'roles:manage', description: 'Criar/editar papéis e suas permissões' },
   { key: 'boletim:write', description: 'Criar/editar boletins' },
+  { key: 'boletim:publish', description: 'Publicar/despublicar boletins' },
   { key: 'settings:manage', description: 'Gerenciar configurações do sistema' },
   { key: 'media:manage', description: 'Gerenciar biblioteca de mídia' },
 ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import Midia from './painel/pages/Midia'
 import Boletins from './painel/pages/Boletins'
 import BoletimEditor from './painel/pages/BoletimEditor'
 import BoletimPreview from './pages/BoletimPreview'
+import BoletimPublico from './pages/BoletimPublico'
 import { AuthProvider } from './auth/AuthContext'
 import { ProtectedRoute } from './auth/ProtectedRoute'
 import { RequirePermission } from './auth/RequirePermission'
@@ -51,6 +52,7 @@ export default function App() {
           <Route path="/sermoes" element={<Sermoes />} />
           <Route path="/galeria" element={<Galeria />} />
         </Route>
+        <Route path="/boletins/:slug" element={<BoletimPublico />} />
         <Route path="/login" element={<Login />} />
         <Route path="/esqueci-senha" element={<EsqueciSenha />} />
         <Route path="/redefinir-senha" element={<RedefinirSenha />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import UsuarioDetalhe from './painel/pages/UsuarioDetalhe'
 import Convites from './painel/pages/Convites'
 import Papeis from './painel/pages/Papeis'
 import Midia from './painel/pages/Midia'
+import Boletins from './painel/pages/Boletins'
+import BoletimEditor from './painel/pages/BoletimEditor'
 import { AuthProvider } from './auth/AuthContext'
 import { ProtectedRoute } from './auth/ProtectedRoute'
 import { RequirePermission } from './auth/RequirePermission'
@@ -60,6 +62,8 @@ export default function App() {
           <Route path="usuarios/papeis" element={<RequirePermission perm="roles:manage"><Papeis /></RequirePermission>} />
           <Route path="usuarios/:id" element={<RequirePermission perm="users:read"><UsuarioDetalhe /></RequirePermission>} />
           <Route path="midia" element={<RequirePermission perm="media:manage"><Midia /></RequirePermission>} />
+          <Route path="boletins" element={<RequirePermission perm="boletim:write"><Boletins /></RequirePermission>} />
+          <Route path="boletins/:id" element={<RequirePermission perm="boletim:write"><BoletimEditor /></RequirePermission>} />
           <Route path="*" element={<EmBreve />} />
         </Route>
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,8 +51,8 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/sermoes" element={<Sermoes />} />
           <Route path="/galeria" element={<Galeria />} />
+          <Route path="/boletins/:slug" element={<BoletimPublico />} />
         </Route>
-        <Route path="/boletins/:slug" element={<BoletimPublico />} />
         <Route path="/login" element={<Login />} />
         <Route path="/esqueci-senha" element={<EsqueciSenha />} />
         <Route path="/redefinir-senha" element={<RedefinirSenha />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import Papeis from './painel/pages/Papeis'
 import Midia from './painel/pages/Midia'
 import Boletins from './painel/pages/Boletins'
 import BoletimEditor from './painel/pages/BoletimEditor'
+import BoletimPreview from './pages/BoletimPreview'
 import { AuthProvider } from './auth/AuthContext'
 import { ProtectedRoute } from './auth/ProtectedRoute'
 import { RequirePermission } from './auth/RequirePermission'
@@ -64,6 +65,7 @@ export default function App() {
           <Route path="midia" element={<RequirePermission perm="media:manage"><Midia /></RequirePermission>} />
           <Route path="boletins" element={<RequirePermission perm="boletim:write"><Boletins /></RequirePermission>} />
           <Route path="boletins/:id" element={<RequirePermission perm="boletim:write"><BoletimEditor /></RequirePermission>} />
+          <Route path="boletins/:id/preview" element={<RequirePermission perm="boletim:write"><BoletimPreview /></RequirePermission>} />
           <Route path="*" element={<EmBreve />} />
         </Route>
       </Routes>

--- a/src/components/boletim/BulletinRenderer.tsx
+++ b/src/components/boletim/BulletinRenderer.tsx
@@ -40,7 +40,7 @@ const GRID_BY_COUNT: Record<number, string> = {
  */
 export default function BulletinRenderer({ content }: { content: Row[] }) {
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
+    <div className="w-full space-y-8">
       {content.map(row => {
         const count = Math.min(4, Math.max(1, row.columns.length))
         return (

--- a/src/components/boletim/BulletinRenderer.tsx
+++ b/src/components/boletim/BulletinRenderer.tsx
@@ -1,0 +1,40 @@
+import type { Block } from '@/schemas/boletim'
+import HeadingBlock from './blocks/HeadingBlock'
+import TextBlock from './blocks/TextBlock'
+import ImageBlock from './blocks/ImageBlock'
+import GalleryBlock from './blocks/GalleryBlock'
+import VideoBlock from './blocks/VideoBlock'
+
+function renderBlock(block: Block) {
+  switch (block.type) {
+    case 'heading':
+      return <HeadingBlock block={block} />
+    case 'text':
+      return <TextBlock block={block} />
+    case 'image':
+      return <ImageBlock block={block} />
+    case 'gallery':
+      return <GalleryBlock block={block} />
+    case 'video':
+      return <VideoBlock block={block} />
+    default: {
+      // Exaustividade: novo tipo de bloco sem branch acima vira erro de tipo.
+      const _exhaustive: never = block
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Renderizador compartilhado do conteúdo do boletim (pré-visualização do editor + página pública).
+ * Mantém largura/espaçamento consistentes com o site.
+ */
+export default function BulletinRenderer({ content }: { content: Block[] }) {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      {content.map(block => (
+        <div key={block.id}>{renderBlock(block)}</div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/boletim/BulletinRenderer.tsx
+++ b/src/components/boletim/BulletinRenderer.tsx
@@ -1,4 +1,4 @@
-import type { Block } from '@/schemas/boletim'
+import type { Block, Row } from '@/schemas/boletim'
 import HeadingBlock from './blocks/HeadingBlock'
 import TextBlock from './blocks/TextBlock'
 import ImageBlock from './blocks/ImageBlock'
@@ -25,16 +25,36 @@ function renderBlock(block: Block) {
   }
 }
 
+// Grade responsiva por número de colunas. Classes listadas LITERALMENTE (sem montar
+// strings dinâmicas) para o purge do Tailwind não removê-las. Colunas empilham no mobile.
+const GRID_BY_COUNT: Record<number, string> = {
+  1: 'grid grid-cols-1',
+  2: 'grid grid-cols-1 md:grid-cols-2',
+  3: 'grid grid-cols-1 md:grid-cols-3',
+  4: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+}
+
 /**
- * Renderizador compartilhado do conteúdo do boletim (pré-visualização do editor + página pública).
- * Mantém largura/espaçamento consistentes com o site.
+ * Renderizador compartilhado do conteúdo do boletim (pré-visualização + página pública).
+ * O conteúdo é uma lista de linhas; cada linha vira uma grade responsiva de N colunas.
  */
-export default function BulletinRenderer({ content }: { content: Block[] }) {
+export default function BulletinRenderer({ content }: { content: Row[] }) {
   return (
-    <div className="mx-auto max-w-3xl space-y-6">
-      {content.map(block => (
-        <div key={block.id}>{renderBlock(block)}</div>
-      ))}
+    <div className="mx-auto max-w-3xl space-y-8">
+      {content.map(row => {
+        const count = Math.min(4, Math.max(1, row.columns.length))
+        return (
+          <div key={row.id} className={`${GRID_BY_COUNT[count]} gap-6`}>
+            {row.columns.map(col => (
+              <div key={col.id} className="space-y-6">
+                {col.blocks.map(block => (
+                  <div key={block.id}>{renderBlock(block)}</div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/boletim/blocks/GalleryBlock.tsx
+++ b/src/components/boletim/blocks/GalleryBlock.tsx
@@ -1,0 +1,19 @@
+import type { GalleryBlock as GalleryBlockType } from '@/schemas/boletim'
+
+/** Galeria de imagens do boletim em grade responsiva. */
+export default function GalleryBlock({ block }: { block: GalleryBlockType }) {
+  const { mediaIds } = block.props
+  return (
+    <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+      {mediaIds.map(id => (
+        <img
+          key={id}
+          src={`/media/${id}`}
+          alt=""
+          loading="lazy"
+          className="aspect-square w-full rounded-lg object-cover shadow-sm"
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/boletim/blocks/HeadingBlock.tsx
+++ b/src/components/boletim/blocks/HeadingBlock.tsx
@@ -1,11 +1,22 @@
 import type { HeadingBlock as HeadingBlockType } from '@/schemas/boletim'
 
-/** Título de seção do boletim (h2/h3), tipografia Montserrat. */
+/**
+ * Título de seção do boletim com faixa de fundo (Montserrat).
+ * H2: faixa sólida azul-escura com texto branco. H3: faixa clara com borda de destaque.
+ */
 export default function HeadingBlock({ block }: { block: HeadingBlockType }) {
   const { text, level } = block.props
-  const Tag = level === 2 ? 'h2' : 'h3'
-  const size = level === 2 ? 'text-2xl md:text-3xl' : 'text-xl md:text-2xl'
+  if (level === 2) {
+    // Faixa azul institucional grande e destacada, com detalhe vermelho à esquerda.
+    return (
+      <h2 className="font-heading text-2xl md:text-3xl font-bold text-white bg-iasd-dark rounded-md border-l-[6px] border-red-600 px-5 py-3 shadow-sm">
+        {text}
+      </h2>
+    )
+  }
   return (
-    <Tag className={`font-heading font-bold text-iasd-dark ${size}`}>{text}</Tag>
+    <h3 className="font-heading text-lg md:text-xl font-semibold text-iasd-dark bg-iasd-accent/10 border-l-4 border-iasd-accent rounded-r-md px-4 py-2">
+      {text}
+    </h3>
   )
 }

--- a/src/components/boletim/blocks/HeadingBlock.tsx
+++ b/src/components/boletim/blocks/HeadingBlock.tsx
@@ -1,0 +1,11 @@
+import type { HeadingBlock as HeadingBlockType } from '@/schemas/boletim'
+
+/** Título de seção do boletim (h2/h3), tipografia Montserrat. */
+export default function HeadingBlock({ block }: { block: HeadingBlockType }) {
+  const { text, level } = block.props
+  const Tag = level === 2 ? 'h2' : 'h3'
+  const size = level === 2 ? 'text-2xl md:text-3xl' : 'text-xl md:text-2xl'
+  return (
+    <Tag className={`font-heading font-bold text-iasd-dark ${size}`}>{text}</Tag>
+  )
+}

--- a/src/components/boletim/blocks/ImageBlock.tsx
+++ b/src/components/boletim/blocks/ImageBlock.tsx
@@ -1,0 +1,14 @@
+import type { ImageBlock as ImageBlockType } from '@/schemas/boletim'
+
+/** Imagem única do boletim, servida por /media/:id. */
+export default function ImageBlock({ block }: { block: ImageBlockType }) {
+  const { mediaId, alt } = block.props
+  return (
+    <img
+      src={`/media/${mediaId}`}
+      alt={alt}
+      loading="lazy"
+      className="w-full max-w-full rounded-lg shadow-sm"
+    />
+  )
+}

--- a/src/components/boletim/blocks/TextBlock.tsx
+++ b/src/components/boletim/blocks/TextBlock.tsx
@@ -1,14 +1,7 @@
 import { useMemo } from 'react'
 import { generateHTML } from '@tiptap/html'
-import StarterKit from '@tiptap/starter-kit'
-import Link from '@tiptap/extension-link'
+import { boletimTextExtensions as extensions } from '../tiptap-extensions'
 import type { TextBlock as TextBlockType } from '@/schemas/boletim'
-
-// Mesmo conjunto de extensões do editor (TextBlockEditor) para que a serialização bata.
-const extensions = [
-  StarterKit,
-  Link.configure({ HTMLAttributes: { rel: 'noopener nofollow', target: '_blank' } }),
-]
 
 /**
  * Renderiza o doc TipTap como HTML. `dangerouslySetInnerHTML` é seguro aqui porque o HTML

--- a/src/components/boletim/blocks/TextBlock.tsx
+++ b/src/components/boletim/blocks/TextBlock.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+import { generateHTML } from '@tiptap/html'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import type { TextBlock as TextBlockType } from '@/schemas/boletim'
+
+// Mesmo conjunto de extensões do editor (TextBlockEditor) para que a serialização bata.
+const extensions = [
+  StarterKit,
+  Link.configure({ HTMLAttributes: { rel: 'noopener nofollow', target: '_blank' } }),
+]
+
+/**
+ * Renderiza o doc TipTap como HTML. `dangerouslySetInnerHTML` é seguro aqui porque o HTML
+ * é gerado por `generateHTML` a partir de um schema conhecido (não é HTML cru do usuário).
+ */
+export default function TextBlock({ block }: { block: TextBlockType }) {
+  const html = useMemo(() => {
+    try {
+      return generateHTML(block.props.doc as Parameters<typeof generateHTML>[0], extensions)
+    } catch {
+      return ''
+    }
+  }, [block.props.doc])
+
+  if (!html) return null
+
+  return (
+    <div
+      className="boletim-prose font-sans text-base leading-relaxed text-gray-800"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/src/components/boletim/blocks/VideoBlock.tsx
+++ b/src/components/boletim/blocks/VideoBlock.tsx
@@ -1,0 +1,18 @@
+import type { VideoBlock as VideoBlockType } from '@/schemas/boletim'
+
+/** Vídeo do YouTube incorporado, responsivo (aspect-video). Padrão de AoVivo.tsx. */
+export default function VideoBlock({ block }: { block: VideoBlockType }) {
+  const { youtubeId } = block.props
+  return (
+    <div className="relative aspect-video overflow-hidden rounded-lg shadow-lg">
+      <iframe
+        src={`https://www.youtube.com/embed/${youtubeId}`}
+        title="Vídeo do YouTube"
+        className="absolute inset-0 h-full w-full"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        loading="lazy"
+      />
+    </div>
+  )
+}

--- a/src/components/boletim/tiptap-extensions.ts
+++ b/src/components/boletim/tiptap-extensions.ts
@@ -1,0 +1,12 @@
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+
+/**
+ * Conjunto ÚNICO de extensões do TipTap usado pelo editor (TextBlockEditor) E pelo renderer
+ * (TextBlock via generateHTML). Importar daqui nos dois lados garante que o HTML gerado bata
+ * exatamente com o que foi editado. Heading limitado a 1-3 (Título 1/2/3).
+ */
+export const boletimTextExtensions = [
+  StarterKit.configure({ heading: { levels: [1, 2, 3] } }),
+  Link.configure({ HTMLAttributes: { rel: 'noopener nofollow', target: '_blank' } }),
+]

--- a/src/globals.css
+++ b/src/globals.css
@@ -17,6 +17,11 @@ html {
 
 /* Estilos do texto rico do boletim (HTML gerado pelo TipTap via generateHTML).
    Não há plugin de typography; estilizamos os elementos do schema manualmente. */
+.boletim-prose {
+  /* Quebra URLs/palavras longas para não estourar a largura (mobile). */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .boletim-prose > * + * {
   margin-top: 1rem;
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -58,13 +58,16 @@ html {
   color: #003366;
 }
 .boletim-prose h1 {
-  font-size: 1.5rem;
+  font-size: 1.875rem;
+  line-height: 1.2;
 }
 .boletim-prose h2 {
-  font-size: 1.375rem;
+  font-size: 1.5rem;
+  line-height: 1.25;
 }
 .boletim-prose h3 {
   font-size: 1.25rem;
+  line-height: 1.3;
 }
 .boletim-prose blockquote {
   border-left: 4px solid #0055aa;

--- a/src/globals.css
+++ b/src/globals.css
@@ -94,3 +94,12 @@ html {
   border: 0;
   border-top: 1px solid #e5e7eb;
 }
+
+/* Fundo padronizado das páginas de boletim (pública + pré-visualização) — pontos sutis
+   na cor da marca sobre o cinza claro, para não ficar "flat". */
+.boletim-bg {
+  background-color: #f5f5f5;
+  background-image: radial-gradient(rgba(0, 51, 102, 0.07) 1.5px, transparent 1.5px);
+  background-size: 20px 20px;
+  background-attachment: fixed;
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -14,3 +14,83 @@ html {
     clip-path: polygon(0 0, 100% 0, 100% 92%, 0 100%);
   }
 }
+
+/* Estilos do texto rico do boletim (HTML gerado pelo TipTap via generateHTML).
+   Não há plugin de typography; estilizamos os elementos do schema manualmente. */
+.boletim-prose > * + * {
+  margin-top: 1rem;
+}
+.boletim-prose p {
+  margin: 0;
+}
+.boletim-prose a {
+  color: #0055aa;
+  text-decoration: underline;
+}
+.boletim-prose strong {
+  font-weight: 700;
+}
+.boletim-prose em {
+  font-style: italic;
+}
+.boletim-prose s {
+  text-decoration: line-through;
+}
+.boletim-prose ul,
+.boletim-prose ol {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+.boletim-prose ul {
+  list-style: disc;
+}
+.boletim-prose ol {
+  list-style: decimal;
+}
+.boletim-prose li > * + * {
+  margin-top: 0.25rem;
+}
+.boletim-prose h1,
+.boletim-prose h2,
+.boletim-prose h3 {
+  font-family: Montserrat, sans-serif;
+  font-weight: 700;
+  color: #003366;
+}
+.boletim-prose h1 {
+  font-size: 1.5rem;
+}
+.boletim-prose h2 {
+  font-size: 1.375rem;
+}
+.boletim-prose h3 {
+  font-size: 1.25rem;
+}
+.boletim-prose blockquote {
+  border-left: 4px solid #0055aa;
+  padding-left: 1rem;
+  color: #4b5563;
+  font-style: italic;
+}
+.boletim-prose code {
+  background: #f5f5f5;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+}
+.boletim-prose pre {
+  background: #003366;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+.boletim-prose pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+.boletim-prose hr {
+  border: 0;
+  border-top: 1px solid #e5e7eb;
+}

--- a/src/pages/BoletimPreview.tsx
+++ b/src/pages/BoletimPreview.tsx
@@ -52,16 +52,16 @@ export default function BoletimPreview() {
   }
 
   return (
-    <main className="min-h-screen bg-iasd-light pb-20 pt-12">
-      <div className="container mx-auto max-w-3xl px-4">
-        <p className="mb-2 text-center text-xs font-medium uppercase tracking-wide text-gray-400">
-          Pré-visualização — última versão salva
-        </p>
+    <main className="boletim-bg min-h-screen px-4 pb-20 pt-10 md:px-8">
+      <p className="mb-2 text-center text-xs font-medium uppercase tracking-wide text-gray-400">
+        Pré-visualização — última versão salva
+      </p>
+      <article className="w-full">
         <h1 className="mb-8 text-center font-heading text-3xl font-bold text-iasd-dark md:text-4xl">
           {boletim.title}
         </h1>
         <BulletinRenderer content={boletim.content} />
-      </div>
+      </article>
     </main>
   )
 }

--- a/src/pages/BoletimPreview.tsx
+++ b/src/pages/BoletimPreview.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { ensureCsrf } from '@/auth/auth-api'
+import { getBoletim, type Boletim } from '@/painel/boletim-api'
+import BulletinRenderer from '@/components/boletim/BulletinRenderer'
+import { Spinner } from '@/painel/ui'
+
+/**
+ * Pré-visualização do boletim (última versão salva). Montada sob /painel, herda a
+ * ProtectedRoute. Renderiza fora do chrome do painel, em um layout limpo e on-brand,
+ * próximo da futura página pública.
+ */
+export default function BoletimPreview() {
+  const { id = '' } = useParams()
+  const [boletim, setBoletim] = useState<Boletim | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    ;(async () => {
+      setLoading(true)
+      await ensureCsrf()
+      try {
+        const b = await getBoletim(id)
+        if (active) setBoletim(b)
+      } catch (e) {
+        if (active) setError((e as Error).message)
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-iasd-light">
+        <Spinner className="h-8 w-8" />
+      </div>
+    )
+  }
+
+  if (error || !boletim) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-iasd-light px-4">
+        <p className="text-center text-gray-600">{error ?? 'Boletim não encontrado.'}</p>
+      </div>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-iasd-light pb-20 pt-12">
+      <div className="container mx-auto max-w-3xl px-4">
+        <p className="mb-2 text-center text-xs font-medium uppercase tracking-wide text-gray-400">
+          Pré-visualização — última versão salva
+        </p>
+        <h1 className="mb-8 text-center font-heading text-3xl font-bold text-iasd-dark md:text-4xl">
+          {boletim.title}
+        </h1>
+        <BulletinRenderer content={boletim.content} />
+      </div>
+    </main>
+  )
+}

--- a/src/pages/BoletimPublico.tsx
+++ b/src/pages/BoletimPublico.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import type { Boletim } from '@/painel/boletim-api'
+import BulletinRenderer from '@/components/boletim/BulletinRenderer'
+import { Spinner } from '@/painel/ui'
+
+type State =
+  | { status: 'loading' }
+  | { status: 'notfound' }
+  | { status: 'ok'; boletim: Boletim }
+
+/**
+ * Página pública do boletim (o que o link compartilhado abre). Sem autenticação;
+ * busca o endpoint público que só retorna boletins publicados (404 caso contrário).
+ */
+export default function BoletimPublico() {
+  const { slug = '' } = useParams()
+  const [state, setState] = useState<State>({ status: 'loading' })
+
+  useEffect(() => {
+    let active = true
+    setState({ status: 'loading' })
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/boletins/${encodeURIComponent(slug)}`)
+        if (!active) return
+        if (!res.ok) {
+          setState({ status: 'notfound' })
+          return
+        }
+        const body = await res.json()
+        setState({ status: 'ok', boletim: body.boletim })
+      } catch {
+        if (active) setState({ status: 'notfound' })
+      }
+    })()
+    return () => {
+      active = false
+    }
+  }, [slug])
+
+  if (state.status === 'loading') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-iasd-light">
+        <Spinner className="h-8 w-8" />
+      </div>
+    )
+  }
+
+  if (state.status === 'notfound') {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-iasd-light px-4 text-center">
+        <h1 className="font-heading text-2xl font-bold text-iasd-dark">Boletim não encontrado</h1>
+        <p className="text-gray-600">Este boletim não está disponível ou o link expirou.</p>
+        <a href="/" className="font-medium text-iasd-accent underline">Voltar ao site</a>
+      </div>
+    )
+  }
+
+  const { boletim } = state
+
+  return (
+    <main className="min-h-screen bg-iasd-light pb-20 pt-12">
+      <article className="container mx-auto max-w-3xl px-4">
+        {boletim.coverMediaId && (
+          <img
+            src={`/media/${boletim.coverMediaId}`}
+            alt={boletim.title}
+            className="mb-8 max-h-96 w-full rounded-xl object-cover shadow-sm"
+          />
+        )}
+        <h1 className="mb-3 text-center font-heading text-3xl font-bold text-iasd-dark md:text-4xl">
+          {boletim.title}
+        </h1>
+        {boletim.summary && (
+          <p className="mb-8 text-center text-lg text-gray-600">{boletim.summary}</p>
+        )}
+        <BulletinRenderer content={boletim.content} />
+      </article>
+    </main>
+  )
+}

--- a/src/pages/BoletimPublico.tsx
+++ b/src/pages/BoletimPublico.tsx
@@ -60,13 +60,13 @@ export default function BoletimPublico() {
   const { boletim } = state
 
   return (
-    <main className="min-h-screen bg-iasd-light pb-20 pt-12">
-      <article className="container mx-auto max-w-3xl px-4">
+    <main className="boletim-bg min-h-screen px-4 pb-20 pt-10 md:px-8">
+      <article className="w-full">
         {boletim.coverMediaId && (
           <img
             src={`/media/${boletim.coverMediaId}`}
             alt={boletim.title}
-            className="mb-8 max-h-96 w-full rounded-xl object-cover shadow-sm"
+            className="mb-8 max-h-[28rem] w-full rounded-xl object-cover shadow-sm"
           />
         )}
         <h1 className="mb-3 text-center font-heading text-3xl font-bold text-iasd-dark md:text-4xl">

--- a/src/pages/BoletimPublico.tsx
+++ b/src/pages/BoletimPublico.tsx
@@ -60,7 +60,7 @@ export default function BoletimPublico() {
   const { boletim } = state
 
   return (
-    <main className="boletim-bg min-h-screen px-4 pb-20 pt-10 md:px-8">
+    <main className="boletim-bg min-h-screen px-4 pb-20 pt-24 md:px-8 md:pt-28">
       <article className="w-full">
         {boletim.coverMediaId && (
           <img

--- a/src/painel/boletim-api.ts
+++ b/src/painel/boletim-api.ts
@@ -1,0 +1,103 @@
+import { adminFetch } from '@/painel/admin-api'
+import type { PageInfo } from '@/painel/usePagination'
+import type { Block } from '@/schemas/boletim'
+
+export interface Boletim {
+  id: string
+  title: string
+  summary: string | null
+  coverMediaId: string | null
+  content: Block[]
+  status: 'draft' | 'published'
+  slug: string | null
+  publicUrl: string | null
+  publishedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+/** Erro lançado por publishBoletim quando o boletim está incompleto (HTTP 400). */
+export class PublishIncompleteError extends Error {
+  constructor(message: string, readonly missing: string[]) {
+    super(message)
+    this.name = 'PublishIncompleteError'
+  }
+}
+
+type UpdatePatch = Partial<Pick<Boletim, 'title' | 'summary' | 'coverMediaId' | 'content'>>
+
+async function errorMessage(res: Response, fallback: string): Promise<string> {
+  const body = await res.json().catch(() => ({}))
+  return body.error ?? fallback
+}
+
+export async function listBoletins(
+  page: number,
+  limit: number,
+): Promise<{ data: Boletim[]; pagination: PageInfo }> {
+  const qs = new URLSearchParams({ page: String(page), limit: String(limit) })
+  const res = await adminFetch(`/boletins?${qs.toString()}`)
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao listar boletins.'))
+  return res.json()
+}
+
+export async function createBoletim(title: string): Promise<Boletim> {
+  const res = await adminFetch('/boletins', { method: 'POST', body: JSON.stringify({ title }) })
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao criar boletim.'))
+  return (await res.json()).boletim
+}
+
+export async function getBoletim(id: string): Promise<Boletim> {
+  const res = await adminFetch(`/boletins/${id}`)
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao carregar boletim.'))
+  return (await res.json()).boletim
+}
+
+export async function updateBoletim(id: string, patch: UpdatePatch): Promise<Boletim> {
+  const res = await adminFetch(`/boletins/${id}`, { method: 'PATCH', body: JSON.stringify(patch) })
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao salvar boletim.'))
+  return (await res.json()).boletim
+}
+
+export async function publishBoletim(id: string): Promise<Boletim> {
+  const res = await adminFetch(`/boletins/${id}/publish`, { method: 'POST' })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    // Publicação incompleta: HTTP 400 com body.details.missing (campos faltantes).
+    if (res.status === 400 && Array.isArray(body?.details?.missing)) {
+      const missing: string[] = body.details.missing
+      const labels = missing.map(labelForMissing).join(', ')
+      throw new PublishIncompleteError(
+        `${body.error ?? 'Boletim incompleto para publicação.'} Faltando: ${labels}.`,
+        missing,
+      )
+    }
+    throw new Error(body.error ?? 'Falha ao publicar boletim.')
+  }
+  return (await res.json()).boletim
+}
+
+export async function unpublishBoletim(id: string): Promise<Boletim> {
+  const res = await adminFetch(`/boletins/${id}/unpublish`, { method: 'POST' })
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao despublicar boletim.'))
+  return (await res.json()).boletim
+}
+
+export async function deleteBoletim(id: string): Promise<void> {
+  const res = await adminFetch(`/boletins/${id}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(await errorMessage(res, 'Falha ao excluir boletim.'))
+}
+
+/** Rótulo amigável para cada chave de campo faltante retornada pelo backend. */
+function labelForMissing(key: string): string {
+  switch (key) {
+    case 'title':
+      return 'título'
+    case 'content':
+      return 'conteúdo (ao menos um bloco)'
+    case 'summary/cover':
+      return 'resumo ou imagem de capa'
+    default:
+      return key
+  }
+}

--- a/src/painel/boletim-api.ts
+++ b/src/painel/boletim-api.ts
@@ -1,13 +1,13 @@
 import { adminFetch } from '@/painel/admin-api'
 import type { PageInfo } from '@/painel/usePagination'
-import type { Block } from '@/schemas/boletim'
+import type { Row } from '@/schemas/boletim'
 
 export interface Boletim {
   id: string
   title: string
   summary: string | null
   coverMediaId: string | null
-  content: Block[]
+  content: Row[]
   status: 'draft' | 'published'
   slug: string | null
   publicUrl: string | null

--- a/src/painel/components/BlockList.tsx
+++ b/src/painel/components/BlockList.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Button } from '@/painel/ui'
-import type { Block, BlockType } from '@/schemas/boletim'
+import { makeBlock, type Block, type BlockType } from '@/schemas/boletim'
 import HeadingEditor from './blocks/HeadingEditor'
 import TextBlockEditor from './blocks/TextBlockEditor'
 import ImageEditor from './blocks/ImageEditor'
@@ -26,6 +26,10 @@ import VideoEditor from './blocks/VideoEditor'
 interface Props {
   blocks: Block[]
   onChange: (next: Block[]) => void
+  /** Habilita o controle "mover ◀ ▶" para deslocar um bloco às colunas adjacentes. */
+  onMoveBlock?: (blockId: string, dir: -1 | 1) => void
+  canMoveLeft?: boolean
+  canMoveRight?: boolean
 }
 
 export const BLOCK_LABELS: Record<BlockType, string> = {
@@ -44,25 +48,17 @@ const ADD_OPTIONS: { type: BlockType; label: string }[] = [
   { type: 'video', label: 'Vídeo' },
 ]
 
-/** Cria um bloco vazio do tipo pedido, com id novo e props padrão sensatas. */
-function makeBlock(type: BlockType): Block {
-  const id = crypto.randomUUID()
-  switch (type) {
-    case 'heading':
-      return { id, type, props: { text: '', level: 2 } }
-    case 'text':
-      return { id, type, props: { doc: {} } }
-    case 'image':
-      return { id, type, props: { mediaId: '', alt: '' } }
-    case 'gallery':
-      return { id, type, props: { mediaIds: [] } }
-    case 'video':
-      return { id, type, props: { youtubeId: '' } }
-  }
-}
-
-/** Lista ordenável de blocos do boletim (arraste para reordenar). */
-export default function BlockList({ blocks, onChange }: Props) {
+/**
+ * Lista ordenável de blocos DE UMA COLUNA (arraste para reordenar dentro da coluna).
+ * Para mover blocos entre colunas use os botões "◀ ▶" (via onMoveBlock).
+ */
+export default function BlockList({
+  blocks,
+  onChange,
+  onMoveBlock,
+  canMoveLeft,
+  canMoveRight,
+}: Props) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -90,10 +86,10 @@ export default function BlockList({ blocks, onChange }: Props) {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {blocks.length === 0 ? (
-        <p className="rounded-lg border border-dashed border-gray-300 px-4 py-8 text-center text-sm text-gray-500">
-          Nenhum bloco ainda. Adicione o primeiro abaixo.
+        <p className="rounded-lg border border-dashed border-gray-300 px-3 py-6 text-center text-xs text-gray-500">
+          Coluna vazia. Adicione um bloco abaixo.
         </p>
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -105,6 +101,9 @@ export default function BlockList({ blocks, onChange }: Props) {
                   block={block}
                   onChange={props => updateBlock(block.id, props)}
                   onRemove={() => removeBlock(block.id)}
+                  onMove={onMoveBlock ? dir => onMoveBlock(block.id, dir) : undefined}
+                  canMoveLeft={canMoveLeft}
+                  canMoveRight={canMoveRight}
                 />
               ))}
             </div>
@@ -112,8 +111,8 @@ export default function BlockList({ blocks, onChange }: Props) {
         </DndContext>
       )}
 
-      <div className="flex flex-wrap items-center gap-2 border-t border-gray-200 pt-4">
-        <span className="text-sm text-gray-500">Adicionar bloco:</span>
+      <div className="flex flex-wrap items-center gap-1.5 border-t border-gray-200 pt-3">
+        <span className="text-xs text-gray-500">Adicionar bloco:</span>
         {ADD_OPTIONS.map(opt => (
           <Button key={opt.type} variant="secondary" size="sm" onClick={() => addBlock(opt.type)}>
             + {opt.label}
@@ -141,10 +140,16 @@ function SortableBlock({
   block,
   onChange,
   onRemove,
+  onMove,
+  canMoveLeft,
+  canMoveRight,
 }: {
   block: Block
   onChange: (props: Block['props']) => void
   onRemove: () => void
+  onMove?: (dir: -1 | 1) => void
+  canMoveLeft?: boolean
+  canMoveRight?: boolean
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: block.id,
@@ -176,14 +181,40 @@ function SortableBlock({
           </button>
           <span className="text-sm font-medium text-iasd-dark">{BLOCK_LABELS[block.type]}</span>
         </div>
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label="Remover bloco"
-          className="rounded px-2 py-1 text-sm text-red-600 hover:bg-red-50"
-        >
-          Remover
-        </button>
+        <div className="flex items-center gap-1">
+          {onMove && (
+            <>
+              <button
+                type="button"
+                onClick={() => onMove(-1)}
+                disabled={!canMoveLeft}
+                aria-label="Mover bloco para a coluna anterior"
+                title="Mover para a coluna anterior"
+                className="rounded px-1.5 py-1 text-sm text-gray-500 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                ◀
+              </button>
+              <button
+                type="button"
+                onClick={() => onMove(1)}
+                disabled={!canMoveRight}
+                aria-label="Mover bloco para a próxima coluna"
+                title="Mover para a próxima coluna"
+                className="rounded px-1.5 py-1 text-sm text-gray-500 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                ▶
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label="Remover bloco"
+            className="rounded px-2 py-1 text-sm text-red-600 hover:bg-red-50"
+          >
+            Remover
+          </button>
+        </div>
       </div>
       <div className="p-4">
         <BlockEditor block={block} onChange={onChange} />

--- a/src/painel/components/BlockList.tsx
+++ b/src/painel/components/BlockList.tsx
@@ -1,0 +1,220 @@
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Button } from '@/painel/ui'
+import type { Block, BlockType } from '@/schemas/boletim'
+import HeadingEditor from './blocks/HeadingEditor'
+import TextBlockEditor from './blocks/TextBlockEditor'
+import ImageEditor from './blocks/ImageEditor'
+import GalleryEditor from './blocks/GalleryEditor'
+import VideoEditor from './blocks/VideoEditor'
+
+interface Props {
+  blocks: Block[]
+  onChange: (next: Block[]) => void
+}
+
+const BLOCK_LABELS: Record<BlockType, string> = {
+  heading: 'Título',
+  text: 'Texto',
+  image: 'Imagem',
+  gallery: 'Galeria',
+  video: 'Vídeo',
+}
+
+const ADD_OPTIONS: { type: BlockType; label: string }[] = [
+  { type: 'heading', label: 'Título' },
+  { type: 'text', label: 'Texto' },
+  { type: 'image', label: 'Imagem' },
+  { type: 'gallery', label: 'Galeria' },
+  { type: 'video', label: 'Vídeo' },
+]
+
+/** Cria um bloco vazio do tipo pedido, com id novo e props padrão sensatas. */
+function makeBlock(type: BlockType): Block {
+  const id = crypto.randomUUID()
+  switch (type) {
+    case 'heading':
+      return { id, type, props: { text: '', level: 2 } }
+    case 'text':
+      return { id, type, props: { doc: {} } }
+    case 'image':
+      return { id, type, props: { mediaId: '', alt: '' } }
+    case 'gallery':
+      return { id, type, props: { mediaIds: [] } }
+    case 'video':
+      return { id, type, props: { youtubeId: '' } }
+  }
+}
+
+/** Lista ordenável de blocos do boletim (arraste para reordenar). */
+export default function BlockList({ blocks, onChange }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = blocks.findIndex(b => b.id === active.id)
+    const newIndex = blocks.findIndex(b => b.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    onChange(arrayMove(blocks, oldIndex, newIndex))
+  }
+
+  function updateBlock(id: string, props: Block['props']) {
+    onChange(blocks.map(b => (b.id === id ? ({ ...b, props } as Block) : b)))
+  }
+
+  function removeBlock(id: string) {
+    onChange(blocks.filter(b => b.id !== id))
+  }
+
+  function addBlock(type: BlockType) {
+    onChange([...blocks, makeBlock(type)])
+  }
+
+  return (
+    <div className="space-y-4">
+      {blocks.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-gray-300 px-4 py-8 text-center text-sm text-gray-500">
+          Nenhum bloco ainda. Adicione o primeiro abaixo.
+        </p>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={blocks.map(b => b.id)} strategy={verticalListSortingStrategy}>
+            <div className="space-y-3">
+              {blocks.map(block => (
+                <SortableBlock
+                  key={block.id}
+                  block={block}
+                  onChange={props => updateBlock(block.id, props)}
+                  onRemove={() => removeBlock(block.id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-gray-200 pt-4">
+        <span className="text-sm text-gray-500">Adicionar bloco:</span>
+        {ADD_OPTIONS.map(opt => (
+          <Button key={opt.type} variant="secondary" size="sm" onClick={() => addBlock(opt.type)}>
+            + {opt.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DragHandleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
+      <circle cx="9" cy="6" r="1.5" />
+      <circle cx="15" cy="6" r="1.5" />
+      <circle cx="9" cy="12" r="1.5" />
+      <circle cx="15" cy="12" r="1.5" />
+      <circle cx="9" cy="18" r="1.5" />
+      <circle cx="15" cy="18" r="1.5" />
+    </svg>
+  )
+}
+
+function SortableBlock({
+  block,
+  onChange,
+  onRemove,
+}: {
+  block: Block
+  onChange: (props: Block['props']) => void
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: block.id,
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-xl border border-gray-200 bg-white shadow-sm ${
+        isDragging ? 'opacity-60 ring-2 ring-iasd-accent' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Arrastar para reordenar"
+            className="cursor-grab touch-none text-gray-400 hover:text-iasd-dark active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+          >
+            <DragHandleIcon />
+          </button>
+          <span className="text-sm font-medium text-iasd-dark">{BLOCK_LABELS[block.type]}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remover bloco"
+          className="rounded px-2 py-1 text-sm text-red-600 hover:bg-red-50"
+        >
+          Remover
+        </button>
+      </div>
+      <div className="p-4">
+        <BlockEditor block={block} onChange={onChange} />
+      </div>
+    </div>
+  )
+}
+
+function BlockEditor({
+  block,
+  onChange,
+}: {
+  block: Block
+  onChange: (props: Block['props']) => void
+}) {
+  switch (block.type) {
+    case 'heading':
+      return <HeadingEditor block={block} onChange={onChange} />
+    case 'text':
+      return (
+        <TextBlockEditor doc={block.props.doc} onChange={doc => onChange({ doc })} />
+      )
+    case 'image':
+      return <ImageEditor block={block} onChange={onChange} />
+    case 'gallery':
+      return <GalleryEditor block={block} onChange={onChange} />
+    case 'video':
+      return <VideoEditor block={block} onChange={onChange} />
+    default: {
+      const _exhaustive: never = block
+      return _exhaustive
+    }
+  }
+}

--- a/src/painel/components/BlockList.tsx
+++ b/src/painel/components/BlockList.tsx
@@ -1,19 +1,4 @@
-import {
-  DndContext,
-  closestCenter,
-  PointerSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from '@dnd-kit/core'
-import {
-  SortableContext,
-  arrayMove,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Button } from '@/painel/ui'
 import { makeBlock, type Block, type BlockType } from '@/schemas/boletim'
@@ -23,15 +8,6 @@ import ImageEditor from './blocks/ImageEditor'
 import GalleryEditor from './blocks/GalleryEditor'
 import VideoEditor from './blocks/VideoEditor'
 
-interface Props {
-  blocks: Block[]
-  onChange: (next: Block[]) => void
-  /** Habilita o controle "mover ◀ ▶" para deslocar um bloco às colunas adjacentes. */
-  onMoveBlock?: (blockId: string, dir: -1 | 1) => void
-  canMoveLeft?: boolean
-  canMoveRight?: boolean
-}
-
 export const BLOCK_LABELS: Record<BlockType, string> = {
   heading: 'Título',
   text: 'Texto',
@@ -39,6 +15,9 @@ export const BLOCK_LABELS: Record<BlockType, string> = {
   gallery: 'Galeria',
   video: 'Vídeo',
 }
+
+/** Prefixo dos ids de bloco arrastáveis no DndContext (em RowList). */
+export const BLOCK_ID_PREFIX = 'blk:'
 
 const ADD_OPTIONS: { type: BlockType; label: string }[] = [
   { type: 'heading', label: 'Título' },
@@ -48,9 +27,20 @@ const ADD_OPTIONS: { type: BlockType; label: string }[] = [
   { type: 'video', label: 'Vídeo' },
 ]
 
+interface Props {
+  blocks: Block[]
+  onChange: (next: Block[]) => void
+  /** Habilita o controle "mover ◀ ▶" para deslocar um bloco às colunas adjacentes (fallback acessível). */
+  onMoveBlock?: (blockId: string, dir: -1 | 1) => void
+  canMoveLeft?: boolean
+  canMoveRight?: boolean
+}
+
 /**
- * Lista ordenável de blocos DE UMA COLUNA (arraste para reordenar dentro da coluna).
- * Para mover blocos entre colunas use os botões "◀ ▶" (via onMoveBlock).
+ * Lista presentacional de blocos DE UMA COLUNA. Não possui DndContext/SortableContext
+ * próprios — eles vivem em RowList (DnD único) e ColumnEditor (SortableContext por coluna).
+ * Arraste o "punho" de cada bloco para reordenar ou movê-lo para qualquer coluna/linha.
+ * Os botões "◀ ▶" permanecem como atalho acessível para colunas adjacentes.
  */
 export default function BlockList({
   blocks,
@@ -59,20 +49,6 @@ export default function BlockList({
   canMoveLeft,
   canMoveRight,
 }: Props) {
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = blocks.findIndex(b => b.id === active.id)
-    const newIndex = blocks.findIndex(b => b.id === over.id)
-    if (oldIndex < 0 || newIndex < 0) return
-    onChange(arrayMove(blocks, oldIndex, newIndex))
-  }
-
   function updateBlock(id: string, props: Block['props']) {
     onChange(blocks.map(b => (b.id === id ? ({ ...b, props } as Block) : b)))
   }
@@ -89,26 +65,22 @@ export default function BlockList({
     <div className="space-y-3">
       {blocks.length === 0 ? (
         <p className="rounded-lg border border-dashed border-gray-300 px-3 py-6 text-center text-xs text-gray-500">
-          Coluna vazia. Adicione um bloco abaixo.
+          Coluna vazia. Adicione um bloco abaixo ou arraste um aqui.
         </p>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={blocks.map(b => b.id)} strategy={verticalListSortingStrategy}>
-            <div className="space-y-3">
-              {blocks.map(block => (
-                <SortableBlock
-                  key={block.id}
-                  block={block}
-                  onChange={props => updateBlock(block.id, props)}
-                  onRemove={() => removeBlock(block.id)}
-                  onMove={onMoveBlock ? dir => onMoveBlock(block.id, dir) : undefined}
-                  canMoveLeft={canMoveLeft}
-                  canMoveRight={canMoveRight}
-                />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
+        <div className="space-y-3">
+          {blocks.map(block => (
+            <SortableBlock
+              key={block.id}
+              block={block}
+              onChange={props => updateBlock(block.id, props)}
+              onRemove={() => removeBlock(block.id)}
+              onMove={onMoveBlock ? dir => onMoveBlock(block.id, dir) : undefined}
+              canMoveLeft={canMoveLeft}
+              canMoveRight={canMoveRight}
+            />
+          ))}
+        </div>
       )}
 
       <div className="flex flex-wrap items-center gap-1.5 border-t border-gray-200 pt-3">
@@ -123,7 +95,7 @@ export default function BlockList({
   )
 }
 
-function DragHandleIcon() {
+export function DragHandleIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
       <circle cx="9" cy="6" r="1.5" />
@@ -152,7 +124,7 @@ function SortableBlock({
   canMoveRight?: boolean
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: block.id,
+    id: BLOCK_ID_PREFIX + block.id,
   })
 
   const style = {
@@ -165,14 +137,14 @@ function SortableBlock({
       ref={setNodeRef}
       style={style}
       className={`rounded-xl border border-gray-200 bg-white shadow-sm ${
-        isDragging ? 'opacity-60 ring-2 ring-iasd-accent' : ''
+        isDragging ? 'opacity-40 ring-2 ring-iasd-accent' : ''
       }`}
     >
       <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-3 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
-            aria-label="Arrastar para reordenar"
+            aria-label="Arrastar para mover ou reordenar o bloco"
             className="cursor-grab touch-none text-gray-400 hover:text-iasd-dark active:cursor-grabbing"
             {...attributes}
             {...listeners}
@@ -234,9 +206,7 @@ function BlockEditor({
     case 'heading':
       return <HeadingEditor block={block} onChange={onChange} />
     case 'text':
-      return (
-        <TextBlockEditor doc={block.props.doc} onChange={doc => onChange({ doc })} />
-      )
+      return <TextBlockEditor doc={block.props.doc} onChange={doc => onChange({ doc })} />
     case 'image':
       return <ImageEditor block={block} onChange={onChange} />
     case 'gallery':

--- a/src/painel/components/BlockList.tsx
+++ b/src/painel/components/BlockList.tsx
@@ -28,7 +28,7 @@ interface Props {
   onChange: (next: Block[]) => void
 }
 
-const BLOCK_LABELS: Record<BlockType, string> = {
+export const BLOCK_LABELS: Record<BlockType, string> = {
   heading: 'Título',
   text: 'Texto',
   image: 'Imagem',

--- a/src/painel/components/ColumnEditor.tsx
+++ b/src/painel/components/ColumnEditor.tsx
@@ -1,0 +1,62 @@
+import type { Block, Column } from '@/schemas/boletim'
+import BlockList from './BlockList'
+
+interface Props {
+  columns: Column[]
+  onChange: (next: Column[]) => void
+}
+
+// Grade da PRÉ-VISUALIZAÇÃO DO EDITOR (lado a lado). Classes literais para o purge do
+// Tailwind. No editor mantemos no máx. 2 colunas por linha em telas médias para caber os
+// editores de bloco; em telas grandes abrimos até 4.
+const EDITOR_GRID_BY_COUNT: Record<number, string> = {
+  1: 'grid grid-cols-1',
+  2: 'grid grid-cols-1 md:grid-cols-2',
+  3: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+  4: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+}
+
+/** Renderiza as colunas de uma linha lado a lado; cada coluna tem sua própria lista de blocos. */
+export default function ColumnEditor({ columns, onChange }: Props) {
+  const count = Math.min(4, Math.max(1, columns.length))
+
+  function setColumnBlocks(colId: string, blocks: Block[]) {
+    onChange(columns.map(c => (c.id === colId ? { ...c, blocks } : c)))
+  }
+
+  /** Move um bloco da coluna `fromIdx` para a adjacente (dir -1 anterior, +1 próxima). */
+  function moveBlock(fromIdx: number, blockId: string, dir: -1 | 1) {
+    const toIdx = fromIdx + dir
+    if (toIdx < 0 || toIdx >= columns.length) return
+    const from = columns[fromIdx]
+    const block = from.blocks.find(b => b.id === blockId)
+    if (!block) return
+    const next = columns.map((c, i) => {
+      if (i === fromIdx) return { ...c, blocks: c.blocks.filter(b => b.id !== blockId) }
+      if (i === toIdx) return { ...c, blocks: [...c.blocks, block] }
+      return c
+    })
+    onChange(next)
+  }
+
+  return (
+    <div className={`${EDITOR_GRID_BY_COUNT[count]} gap-3`}>
+      {columns.map((col, idx) => (
+        <div key={col.id} className="rounded-lg border border-gray-200 bg-gray-50/60 p-3">
+          {columns.length > 1 && (
+            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">
+              Coluna {idx + 1}
+            </div>
+          )}
+          <BlockList
+            blocks={col.blocks}
+            onChange={blocks => setColumnBlocks(col.id, blocks)}
+            onMoveBlock={columns.length > 1 ? (bid, dir) => moveBlock(idx, bid, dir) : undefined}
+            canMoveLeft={idx > 0}
+            canMoveRight={idx < columns.length - 1}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/painel/components/ColumnEditor.tsx
+++ b/src/painel/components/ColumnEditor.tsx
@@ -1,9 +1,29 @@
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { Block, Column } from '@/schemas/boletim'
-import BlockList from './BlockList'
+import BlockList, { BLOCK_ID_PREFIX } from './BlockList'
 
 interface Props {
+  /** Id da linha dona destas colunas — compõe o id do droppable de cada coluna. */
+  rowId: string
   columns: Column[]
   onChange: (next: Column[]) => void
+}
+
+/** Prefixo do id de droppable de uma coluna: `col:<rowId>::<colId>`. */
+export const COLUMN_DROPPABLE_PREFIX = 'col:'
+
+export function columnDroppableId(rowId: string, colId: string): string {
+  return `${COLUMN_DROPPABLE_PREFIX}${rowId}::${colId}`
+}
+
+/** Decodifica `col:<rowId>::<colId>` → { rowId, colId } ou null. */
+export function parseColumnDroppableId(id: string): { rowId: string; colId: string } | null {
+  if (!id.startsWith(COLUMN_DROPPABLE_PREFIX)) return null
+  const rest = id.slice(COLUMN_DROPPABLE_PREFIX.length)
+  const sep = rest.indexOf('::')
+  if (sep < 0) return null
+  return { rowId: rest.slice(0, sep), colId: rest.slice(sep + 2) }
 }
 
 // Grade da PRÉ-VISUALIZAÇÃO DO EDITOR (lado a lado). Classes literais para o purge do
@@ -16,15 +36,19 @@ const EDITOR_GRID_BY_COUNT: Record<number, string> = {
   4: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
 }
 
-/** Renderiza as colunas de uma linha lado a lado; cada coluna tem sua própria lista de blocos. */
-export default function ColumnEditor({ columns, onChange }: Props) {
+/**
+ * Renderiza as colunas de uma linha lado a lado. O DndContext é único e vive em RowList;
+ * aqui cada coluna recebe seu próprio SortableContext (blocos da coluna) e é um droppable
+ * (para aceitar blocos arrastados de outras colunas, inclusive quando vazia).
+ */
+export default function ColumnEditor({ rowId, columns, onChange }: Props) {
   const count = Math.min(4, Math.max(1, columns.length))
 
   function setColumnBlocks(colId: string, blocks: Block[]) {
     onChange(columns.map(c => (c.id === colId ? { ...c, blocks } : c)))
   }
 
-  /** Move um bloco da coluna `fromIdx` para a adjacente (dir -1 anterior, +1 próxima). */
+  /** Move um bloco da coluna `fromIdx` para a adjacente (dir -1 anterior, +1 próxima). Fallback acessível. */
   function moveBlock(fromIdx: number, blockId: string, dir: -1 | 1) {
     const toIdx = fromIdx + dir
     if (toIdx < 0 || toIdx >= columns.length) return
@@ -42,21 +66,52 @@ export default function ColumnEditor({ columns, onChange }: Props) {
   return (
     <div className={`${EDITOR_GRID_BY_COUNT[count]} gap-3`}>
       {columns.map((col, idx) => (
-        <div key={col.id} className="rounded-lg border border-gray-200 bg-gray-50/60 p-3">
-          {columns.length > 1 && (
-            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">
-              Coluna {idx + 1}
-            </div>
-          )}
-          <BlockList
-            blocks={col.blocks}
-            onChange={blocks => setColumnBlocks(col.id, blocks)}
-            onMoveBlock={columns.length > 1 ? (bid, dir) => moveBlock(idx, bid, dir) : undefined}
-            canMoveLeft={idx > 0}
-            canMoveRight={idx < columns.length - 1}
-          />
-        </div>
+        <DroppableColumn key={col.id} rowId={rowId} col={col} index={idx} showLabel={columns.length > 1}>
+          <SortableContext
+            items={col.blocks.map(b => BLOCK_ID_PREFIX + b.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <BlockList
+              blocks={col.blocks}
+              onChange={blocks => setColumnBlocks(col.id, blocks)}
+              onMoveBlock={columns.length > 1 ? (bid, dir) => moveBlock(idx, bid, dir) : undefined}
+              canMoveLeft={idx > 0}
+              canMoveRight={idx < columns.length - 1}
+            />
+          </SortableContext>
+        </DroppableColumn>
       ))}
+    </div>
+  )
+}
+
+function DroppableColumn({
+  rowId,
+  col,
+  index,
+  showLabel,
+  children,
+}: {
+  rowId: string
+  col: Column
+  index: number
+  showLabel: boolean
+  children: React.ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: columnDroppableId(rowId, col.id) })
+  return (
+    <div
+      ref={setNodeRef}
+      className={`rounded-lg border bg-gray-50/60 p-3 transition-colors ${
+        isOver ? 'border-iasd-accent bg-iasd-accent/5' : 'border-gray-200'
+      }`}
+    >
+      {showLabel && (
+        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">
+          Coluna {index + 1}
+        </div>
+      )}
+      {children}
     </div>
   )
 }

--- a/src/painel/components/MediaPicker.tsx
+++ b/src/painel/components/MediaPicker.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 import { usePagination, type PageInfo } from '@/painel/usePagination'
-import { listMedia, type MediaItem } from '@/painel/media-api'
-import { Field, Input, Alert, EmptyState, Spinner, Modal, Pager, Button } from '@/painel/ui'
+import { listMedia, uploadMedia, type MediaItem } from '@/painel/media-api'
+import { Field, Input, Alert, type Message, EmptyState, Spinner, Modal, Pager, Button } from '@/painel/ui'
+
+const MAX_BYTES = 5 * 1024 * 1024
+const ACCEPT = ['image/jpeg', 'image/png', 'image/webp']
 
 interface BaseProps {
   open: boolean
@@ -20,14 +23,20 @@ interface MultipleProps extends BaseProps {
 
 type MediaPickerProps = SingleProps | MultipleProps
 
+type Tab = 'library' | 'upload'
+
 /**
- * Modal de seleção de imagens da biblioteca de mídia (grade paginada + busca por nome).
- * - `multiple` false (padrão): clicar numa miniatura seleciona e chama onSelect(id).
- * - `multiple` true: multi-seleção com botão de confirmação chamando onSelect(ids).
+ * Modal de seleção de imagens com duas abas:
+ * - **Biblioteca**: grade paginada + busca por nome (clicar seleciona; em multi, checkbox + Adicionar).
+ * - **Enviar**: upload de nova imagem (mesmas regras da Biblioteca de mídia: JPEG/PNG/WebP, máx. 5 MB).
+ *
+ * Contrato (igual à versão anterior):
+ * - `multiple` false (padrão): clicar numa miniatura — ou enviar uma nova — chama onSelect(id) e fecha.
+ * - `multiple` true: multi-seleção com botão de confirmação chamando onSelect(ids); upload adiciona à seleção.
  * Fecha CA-04 da US-17.
  */
 export default function MediaPicker(props: MediaPickerProps) {
-  const { open, onClose } = props
+  const { open } = props
   if (!open) return null
   return <MediaPickerInner {...props} />
 }
@@ -35,6 +44,8 @@ export default function MediaPicker(props: MediaPickerProps) {
 function MediaPickerInner(props: MediaPickerProps) {
   const { onClose } = props
   const multiple = props.multiple === true
+
+  const [tab, setTab] = useState<Tab>('library')
 
   const { page, limit, setPage } = usePagination()
   const [items, setItems] = useState<MediaItem[]>([])
@@ -81,70 +92,182 @@ function MediaPickerInner(props: MediaPickerProps) {
     onClose()
   }
 
+  // Após upload: recarrega a lista para o novo item aparecer e decide o destino conforme o modo.
+  const handleUploaded = useCallback(
+    async (uploaded: MediaItem) => {
+      setPage(1)
+      await load()
+      if (multiple) {
+        setSelected(prev => (prev.includes(uploaded.id) ? prev : [...prev, uploaded.id]))
+        setTab('library')
+      } else {
+        ;(props as SingleProps).onSelect(uploaded.id)
+        onClose()
+      }
+    },
+    [load, multiple, onClose, props, setPage],
+  )
+
   return (
-    <Modal title="Selecionar da biblioteca" onClose={onClose} size="xl">
+    <Modal title="Selecionar imagem" onClose={onClose} size="xl">
       <div className="space-y-4">
-        <Field label="Buscar por nome">
-          <Input
-            value={q}
-            onChange={e => { setPage(1); setQ(e.target.value) }}
-            placeholder="Nome do arquivo…"
-          />
-        </Field>
+        <Tabs tab={tab} onTab={setTab} />
 
-        {error && <Alert kind="err">{error}</Alert>}
+        {tab === 'library' ? (
+          <div className="space-y-4">
+            <Field label="Buscar por nome">
+              <Input
+                value={q}
+                onChange={e => { setPage(1); setQ(e.target.value) }}
+                placeholder="Nome do arquivo…"
+              />
+            </Field>
 
-        {loading ? (
-          <div className="flex justify-center py-16"><Spinner className="w-8 h-8" /></div>
-        ) : items.length === 0 ? (
-          <EmptyState title="Nenhuma imagem" description="Envie imagens na biblioteca de mídia primeiro." />
-        ) : (
-          <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
-            {items.map(m => {
-              const isSel = selected.includes(m.id)
-              return (
-                <button
-                  key={m.id}
-                  type="button"
-                  onClick={() => handlePick(m)}
-                  aria-pressed={multiple ? isSel : undefined}
-                  className={`group relative block overflow-hidden rounded-lg border bg-gray-100 transition
-                    ${isSel ? 'border-iasd-accent ring-2 ring-iasd-accent' : 'border-gray-200 hover:border-iasd-accent'}`}
-                  title={m.originalName}
-                >
-                  <div className="aspect-square">
-                    <img
-                      src={m.thumbnailUrl}
-                      alt={m.originalName}
-                      loading="lazy"
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                  {multiple && isSel && (
-                    <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-iasd-accent text-xs font-bold text-white">
-                      ✓
-                    </span>
-                  )}
-                </button>
-              )
-            })}
+            {error && <Alert kind="err">{error}</Alert>}
+
+            {loading ? (
+              <div className="flex justify-center py-16"><Spinner className="w-8 h-8" /></div>
+            ) : items.length === 0 ? (
+              <EmptyState title="Nenhuma imagem" description="Envie uma imagem pela aba “Enviar”." />
+            ) : (
+              <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
+                {items.map(m => {
+                  const isSel = selected.includes(m.id)
+                  return (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => handlePick(m)}
+                      aria-pressed={multiple ? isSel : undefined}
+                      className={`group relative block overflow-hidden rounded-lg border bg-gray-100 transition
+                        ${isSel ? 'border-iasd-accent ring-2 ring-iasd-accent' : 'border-gray-200 hover:border-iasd-accent'}`}
+                      title={m.originalName}
+                    >
+                      <div className="aspect-square">
+                        <img
+                          src={m.thumbnailUrl}
+                          alt={m.originalName}
+                          loading="lazy"
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                      {multiple && isSel && (
+                        <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-iasd-accent text-xs font-bold text-white">
+                          ✓
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+
+            {!loading && info && <Pager info={info} onPage={setPage} />}
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              {multiple && (
+                <span className="mr-auto text-sm text-gray-500">
+                  {selected.length} selecionada{selected.length === 1 ? '' : 's'}
+                </span>
+              )}
+              <Button variant="secondary" onClick={onClose}>Cancelar</Button>
+              {multiple && (
+                <Button onClick={confirm} disabled={selected.length === 0}>Adicionar</Button>
+              )}
+            </div>
           </div>
+        ) : (
+          <UploadTab onUploaded={handleUploaded} onCancel={onClose} />
         )}
-
-        {!loading && info && <Pager info={info} onPage={setPage} />}
-
-        <div className="flex items-center justify-end gap-2 pt-2">
-          {multiple && (
-            <span className="mr-auto text-sm text-gray-500">
-              {selected.length} selecionada{selected.length === 1 ? '' : 's'}
-            </span>
-          )}
-          <Button variant="secondary" onClick={onClose}>Cancelar</Button>
-          {multiple && (
-            <Button onClick={confirm} disabled={selected.length === 0}>Adicionar</Button>
-          )}
-        </div>
       </div>
     </Modal>
+  )
+}
+
+function Tabs({ tab, onTab }: { tab: Tab; onTab: (t: Tab) => void }) {
+  const tabClass = (t: Tab) =>
+    `px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+      tab === t
+        ? 'border-iasd-accent text-iasd-dark'
+        : 'border-transparent text-gray-500 hover:text-iasd-dark'
+    }`
+  return (
+    <div className="flex gap-2 border-b border-gray-200" role="tablist">
+      <button type="button" role="tab" aria-selected={tab === 'library'} className={tabClass('library')} onClick={() => onTab('library')}>
+        Biblioteca
+      </button>
+      <button type="button" role="tab" aria-selected={tab === 'upload'} className={tabClass('upload')} onClick={() => onTab('upload')}>
+        Enviar
+      </button>
+    </div>
+  )
+}
+
+function UploadTab({ onUploaded, onCancel }: { onUploaded: (m: MediaItem) => void | Promise<void>; onCancel: () => void }) {
+  const [file, setFile] = useState<File | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [msg, setMsg] = useState<Message | null>(null)
+
+  // Object URL da pré-visualização; revoga ao trocar de arquivo ou desmontar.
+  useEffect(() => {
+    if (!file) { setPreview(null); return }
+    const url = URL.createObjectURL(file)
+    setPreview(url)
+    return () => URL.revokeObjectURL(url)
+  }, [file])
+
+  function pick(f: File | undefined) {
+    setMsg(null)
+    if (!f) { setFile(null); return }
+    if (!ACCEPT.includes(f.type)) { setFile(null); setMsg({ kind: 'err', text: 'Tipo não suportado. Use JPEG, PNG ou WebP.' }); return }
+    if (f.size > MAX_BYTES) { setFile(null); setMsg({ kind: 'err', text: 'Arquivo muito grande (máx. 5 MB).' }); return }
+    setFile(f)
+  }
+
+  async function send() {
+    if (!file || busy) return
+    setMsg(null); setBusy(true)
+    try {
+      const uploaded = await uploadMedia(file)
+      setMsg({ kind: 'ok', text: 'Imagem enviada com sucesso.' })
+      await onUploaded(uploaded)
+    } catch (e) {
+      setMsg({ kind: 'err', text: (e as Error).message })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="file"
+        accept={ACCEPT.join(',')}
+        disabled={busy}
+        onChange={e => pick(e.target.files?.[0])}
+        className="block w-full text-sm text-gray-600 file:mr-3 file:rounded-lg file:border-0
+          file:bg-iasd-accent file:px-4 file:py-2 file:text-white file:font-medium"
+      />
+      <p className="text-xs text-gray-500">JPEG, PNG ou WebP · máximo 5 MB.</p>
+
+      {preview && (
+        <div className="space-y-1">
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+            <img src={preview} alt={file?.name ?? 'Pré-visualização'} className="mx-auto max-h-64 w-auto object-contain" />
+          </div>
+          {file && <p className="truncate text-xs text-gray-500" title={file.name}>{file.name}</p>}
+        </div>
+      )}
+
+      <Alert message={msg} />
+
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <Button variant="secondary" onClick={onCancel} disabled={busy}>Cancelar</Button>
+        <Button onClick={send} disabled={!file || busy}>
+          {busy ? (<><Spinner className="h-4 w-4" /> Enviando…</>) : 'Enviar'}
+        </Button>
+      </div>
+    </div>
   )
 }

--- a/src/painel/components/MediaPicker.tsx
+++ b/src/painel/components/MediaPicker.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useState } from 'react'
+import { usePagination, type PageInfo } from '@/painel/usePagination'
+import { listMedia, type MediaItem } from '@/painel/media-api'
+import { Field, Input, Alert, EmptyState, Spinner, Modal, Pager, Button } from '@/painel/ui'
+
+interface BaseProps {
+  open: boolean
+  onClose: () => void
+}
+
+interface SingleProps extends BaseProps {
+  multiple?: false
+  onSelect: (id: string) => void
+}
+
+interface MultipleProps extends BaseProps {
+  multiple: true
+  onSelect: (ids: string[]) => void
+}
+
+type MediaPickerProps = SingleProps | MultipleProps
+
+/**
+ * Modal de seleção de imagens da biblioteca de mídia (grade paginada + busca por nome).
+ * - `multiple` false (padrão): clicar numa miniatura seleciona e chama onSelect(id).
+ * - `multiple` true: multi-seleção com botão de confirmação chamando onSelect(ids).
+ * Fecha CA-04 da US-17.
+ */
+export default function MediaPicker(props: MediaPickerProps) {
+  const { open, onClose } = props
+  if (!open) return null
+  return <MediaPickerInner {...props} />
+}
+
+function MediaPickerInner(props: MediaPickerProps) {
+  const { onClose } = props
+  const multiple = props.multiple === true
+
+  const { page, limit, setPage } = usePagination()
+  const [items, setItems] = useState<MediaItem[]>([])
+  const [info, setInfo] = useState<PageInfo | null>(null)
+  const [q, setQ] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const body = await listMedia(page, limit, q)
+      setError(null)
+      setItems(body.data)
+      setInfo(body.pagination)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [page, limit, q])
+
+  // debounce: recarrega 300ms após a última mudança de página/busca
+  useEffect(() => {
+    setLoading(true)
+    const t = setTimeout(load, 300)
+    return () => clearTimeout(t)
+  }, [load])
+
+  function handlePick(item: MediaItem) {
+    if (multiple) {
+      setSelected(prev =>
+        prev.includes(item.id) ? prev.filter(x => x !== item.id) : [...prev, item.id],
+      )
+    } else {
+      ;(props as SingleProps).onSelect(item.id)
+      onClose()
+    }
+  }
+
+  function confirm() {
+    if (!multiple || selected.length === 0) return
+    ;(props as MultipleProps).onSelect(selected)
+    onClose()
+  }
+
+  return (
+    <Modal title="Selecionar da biblioteca" onClose={onClose} size="xl">
+      <div className="space-y-4">
+        <Field label="Buscar por nome">
+          <Input
+            value={q}
+            onChange={e => { setPage(1); setQ(e.target.value) }}
+            placeholder="Nome do arquivo…"
+          />
+        </Field>
+
+        {error && <Alert kind="err">{error}</Alert>}
+
+        {loading ? (
+          <div className="flex justify-center py-16"><Spinner className="w-8 h-8" /></div>
+        ) : items.length === 0 ? (
+          <EmptyState title="Nenhuma imagem" description="Envie imagens na biblioteca de mídia primeiro." />
+        ) : (
+          <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5">
+            {items.map(m => {
+              const isSel = selected.includes(m.id)
+              return (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => handlePick(m)}
+                  aria-pressed={multiple ? isSel : undefined}
+                  className={`group relative block overflow-hidden rounded-lg border bg-gray-100 transition
+                    ${isSel ? 'border-iasd-accent ring-2 ring-iasd-accent' : 'border-gray-200 hover:border-iasd-accent'}`}
+                  title={m.originalName}
+                >
+                  <div className="aspect-square">
+                    <img
+                      src={m.thumbnailUrl}
+                      alt={m.originalName}
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                  {multiple && isSel && (
+                    <span className="absolute right-1.5 top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-iasd-accent text-xs font-bold text-white">
+                      ✓
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {!loading && info && <Pager info={info} onPage={setPage} />}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          {multiple && (
+            <span className="mr-auto text-sm text-gray-500">
+              {selected.length} selecionada{selected.length === 1 ? '' : 's'}
+            </span>
+          )}
+          <Button variant="secondary" onClick={onClose}>Cancelar</Button>
+          {multiple && (
+            <Button onClick={confirm} disabled={selected.length === 0}>Adicionar</Button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/painel/components/RowList.tsx
+++ b/src/painel/components/RowList.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react'
 import {
   DndContext,
-  closestCenter,
+  DragOverlay,
+  closestCorners,
   PointerSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
+  type DragStartEvent,
+  type DragOverEvent,
   type DragEndEvent,
 } from '@dnd-kit/core'
 import {
@@ -16,8 +20,9 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Button } from '@/painel/ui'
-import { makeColumn, makeRow, type Column, type Row } from '@/schemas/boletim'
-import ColumnEditor from './ColumnEditor'
+import { makeColumn, makeRow, type Block, type Column, type Row } from '@/schemas/boletim'
+import ColumnEditor, { parseColumnDroppableId } from './ColumnEditor'
+import { BLOCK_LABELS, BLOCK_ID_PREFIX, DragHandleIcon } from './BlockList'
 
 interface Props {
   rows: Row[]
@@ -25,21 +30,179 @@ interface Props {
 }
 
 const COLUMN_COUNTS = [1, 2, 3, 4] as const
+const ROW_ID_PREFIX = 'row:'
+
+// ── Id helpers ────────────────────────────────────────────────────────────────
+const isRowId = (id: string) => id.startsWith(ROW_ID_PREFIX)
+const isBlockId = (id: string) => id.startsWith(BLOCK_ID_PREFIX)
+const stripRow = (id: string) => id.slice(ROW_ID_PREFIX.length)
+const stripBlock = (id: string) => id.slice(BLOCK_ID_PREFIX.length)
+
+// ── Pure lookups / moves over Row[] ─────────────────────────────────────────────
+
+type BlockLoc = { rowIdx: number; colIdx: number; blockIdx: number }
+
+/** Localiza um bloco pelo seu id (sem prefixo) varrendo linhas→colunas→blocos. */
+function findBlock(rows: Row[], blockId: string): BlockLoc | null {
+  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+    const cols = rows[rowIdx].columns
+    for (let colIdx = 0; colIdx < cols.length; colIdx++) {
+      const blockIdx = cols[colIdx].blocks.findIndex(b => b.id === blockId)
+      if (blockIdx >= 0) return { rowIdx, colIdx, blockIdx }
+    }
+  }
+  return null
+}
+
+/** Localiza uma coluna a partir do id de droppable `col:<rowId>::<colId>`. */
+function findColumnByDroppableId(
+  rows: Row[],
+  droppableId: string,
+): { rowIdx: number; colIdx: number } | null {
+  const parsed = parseColumnDroppableId(droppableId)
+  if (!parsed) return null
+  const rowIdx = rows.findIndex(r => r.id === parsed.rowId)
+  if (rowIdx < 0) return null
+  const colIdx = rows[rowIdx].columns.findIndex(c => c.id === parsed.colId)
+  if (colIdx < 0) return null
+  return { rowIdx, colIdx }
+}
+
+/**
+ * Move imutavelmente um bloco de uma posição (linha/coluna/índice) para outra coluna,
+ * inserindo no índice indicado (`toBlockIdx`; use o tamanho da coluna destino p/ anexar).
+ */
+function moveBlock(
+  rows: Row[],
+  from: BlockLoc,
+  to: { rowIdx: number; colIdx: number; blockIdx: number },
+): Row[] {
+  const block = rows[from.rowIdx]?.columns[from.colIdx]?.blocks[from.blockIdx]
+  if (!block) return rows
+
+  return rows.map((row, ri) => {
+    const touchesFrom = ri === from.rowIdx
+    const touchesTo = ri === to.rowIdx
+    if (!touchesFrom && !touchesTo) return row
+
+    const columns = row.columns.map((col, ci) => {
+      let blocks = col.blocks
+      // remover da origem
+      if (touchesFrom && ci === from.colIdx) {
+        blocks = blocks.filter(b => b.id !== block.id)
+      }
+      // inserir no destino (recalculando sobre a lista possivelmente já filtrada)
+      if (touchesTo && ci === to.colIdx) {
+        const idx = Math.max(0, Math.min(to.blockIdx, blocks.length))
+        blocks = [...blocks.slice(0, idx), block, ...blocks.slice(idx)]
+      }
+      return blocks === col.blocks ? col : { ...col, blocks }
+    })
+    return { ...row, columns }
+  })
+}
 
 /** Editor do conteúdo: lista de linhas ordenáveis, cada uma com 1..4 colunas de blocos. */
 export default function RowList({ rows, onChange }: Props) {
+  const [activeRowId, setActiveRowId] = useState<string | null>(null)
+  const [activeBlock, setActiveBlock] = useState<Block | null>(null)
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   )
 
+  /** Dado o id do alvo (over), descobre a coluna+índice de inserção destino p/ um bloco. */
+  function resolveBlockTarget(
+    current: Row[],
+    overId: string,
+  ): { rowIdx: number; colIdx: number; blockIdx: number } | null {
+    if (isBlockId(overId)) {
+      const loc = findBlock(current, stripBlock(overId))
+      if (!loc) return null
+      return { rowIdx: loc.rowIdx, colIdx: loc.colIdx, blockIdx: loc.blockIdx }
+    }
+    const col = findColumnByDroppableId(current, overId)
+    if (!col) return null
+    // soltar sobre a coluna (área vazia) → anexa ao fim
+    return { rowIdx: col.rowIdx, colIdx: col.colIdx, blockIdx: current[col.rowIdx].columns[col.colIdx].blocks.length }
+  }
+
+  function handleDragStart(event: DragStartEvent) {
+    const id = String(event.active.id)
+    if (isRowId(id)) {
+      setActiveRowId(stripRow(id))
+      return
+    }
+    if (isBlockId(id)) {
+      const loc = findBlock(rows, stripBlock(id))
+      if (loc) setActiveBlock(rows[loc.rowIdx].columns[loc.colIdx].blocks[loc.blockIdx])
+    }
+  }
+
+  /** Move blocos entre colunas/linhas ao vivo (padrão multi-container). Ignora drags de linha. */
+  function handleDragOver(event: DragOverEvent) {
+    const { active, over } = event
+    if (!over) return
+    const activeId = String(active.id)
+    const overId = String(over.id)
+    if (!isBlockId(activeId)) return // linhas: nada a fazer no over
+
+    const from = findBlock(rows, stripBlock(activeId))
+    if (!from) return
+    const target = resolveBlockTarget(rows, overId)
+    if (!target) return
+
+    // mesma coluna → o SortableContext já cuida do preview; nada a mover aqui.
+    if (from.rowIdx === target.rowIdx && from.colIdx === target.colIdx) return
+
+    // move para a coluna destino (insere na posição do alvo, ou ao fim em coluna vazia)
+    onChange(moveBlock(rows, from, target))
+  }
+
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = rows.findIndex(r => r.id === active.id)
-    const newIndex = rows.findIndex(r => r.id === over.id)
-    if (oldIndex < 0 || newIndex < 0) return
-    onChange(arrayMove(rows, oldIndex, newIndex))
+    setActiveRowId(null)
+    setActiveBlock(null)
+    if (!over) return
+    const activeId = String(active.id)
+    const overId = String(over.id)
+
+    // ── Reordenar LINHAS ──
+    if (isRowId(activeId)) {
+      if (!isRowId(overId)) return
+      const oldIndex = rows.findIndex(r => ROW_ID_PREFIX + r.id === activeId)
+      const newIndex = rows.findIndex(r => ROW_ID_PREFIX + r.id === overId)
+      if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) return
+      onChange(arrayMove(rows, oldIndex, newIndex))
+      return
+    }
+
+    // ── Finalizar BLOCO (cross-column já aplicado no dragOver; aqui reordena dentro do destino) ──
+    if (isBlockId(activeId)) {
+      const from = findBlock(rows, stripBlock(activeId))
+      if (!from) return
+      const target = resolveBlockTarget(rows, overId)
+      if (!target) return
+      if (from.rowIdx === target.rowIdx && from.colIdx === target.colIdx) {
+        if (from.blockIdx === target.blockIdx) return
+        const next = rows.map((row, ri) => {
+          if (ri !== from.rowIdx) return row
+          const columns = row.columns.map((col, ci) => {
+            if (ci !== from.colIdx) return col
+            return { ...col, blocks: arrayMove(col.blocks, from.blockIdx, target.blockIdx) }
+          })
+          return { ...row, columns }
+        })
+        onChange(next)
+      }
+      // posições em coluna diferente já foram consolidadas no handleDragOver.
+    }
+  }
+
+  function handleDragCancel() {
+    setActiveRowId(null)
+    setActiveBlock(null)
   }
 
   function setRowColumns(rowId: string, columns: Column[]) {
@@ -86,8 +249,18 @@ export default function RowList({ rows, onChange }: Props) {
           Nenhuma linha ainda. Adicione a primeira abaixo.
         </p>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={rows.map(r => r.id)} strategy={verticalListSortingStrategy}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <SortableContext
+            items={rows.map(r => ROW_ID_PREFIX + r.id)}
+            strategy={verticalListSortingStrategy}
+          >
             <div className="space-y-4">
               {rows.map((row, idx) => (
                 <SortableRow
@@ -101,6 +274,22 @@ export default function RowList({ rows, onChange }: Props) {
               ))}
             </div>
           </SortableContext>
+
+          <DragOverlay>
+            {activeBlock ? (
+              <div className="flex items-center gap-2 rounded-xl border border-iasd-accent bg-white px-3 py-2 shadow-lg">
+                <DragHandleIcon />
+                <span className="text-sm font-medium text-iasd-dark">
+                  {BLOCK_LABELS[activeBlock.type]}
+                </span>
+              </div>
+            ) : activeRowId ? (
+              <div className="flex items-center gap-2 rounded-xl border border-iasd-accent bg-white px-3 py-2 shadow-lg">
+                <DragHandleIcon />
+                <span className="text-sm font-semibold text-iasd-dark">Linha</span>
+              </div>
+            ) : null}
+          </DragOverlay>
         </DndContext>
       )}
 
@@ -110,19 +299,6 @@ export default function RowList({ rows, onChange }: Props) {
         </Button>
       </div>
     </div>
-  )
-}
-
-function DragHandleIcon() {
-  return (
-    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
-      <circle cx="9" cy="6" r="1.5" />
-      <circle cx="15" cy="6" r="1.5" />
-      <circle cx="9" cy="12" r="1.5" />
-      <circle cx="15" cy="12" r="1.5" />
-      <circle cx="9" cy="18" r="1.5" />
-      <circle cx="15" cy="18" r="1.5" />
-    </svg>
   )
 }
 
@@ -140,7 +316,7 @@ function SortableRow({
   onRemove: () => void
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: row.id,
+    id: ROW_ID_PREFIX + row.id,
   })
 
   const style = {
@@ -204,7 +380,7 @@ function SortableRow({
         </div>
       </div>
       <div className="p-3">
-        <ColumnEditor columns={row.columns} onChange={onColumns} />
+        <ColumnEditor rowId={row.id} columns={row.columns} onChange={onColumns} />
       </div>
     </div>
   )

--- a/src/painel/components/RowList.tsx
+++ b/src/painel/components/RowList.tsx
@@ -1,0 +1,211 @@
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { Button } from '@/painel/ui'
+import { makeColumn, makeRow, type Column, type Row } from '@/schemas/boletim'
+import ColumnEditor from './ColumnEditor'
+
+interface Props {
+  rows: Row[]
+  onChange: (next: Row[]) => void
+}
+
+const COLUMN_COUNTS = [1, 2, 3, 4] as const
+
+/** Editor do conteúdo: lista de linhas ordenáveis, cada uma com 1..4 colunas de blocos. */
+export default function RowList({ rows, onChange }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = rows.findIndex(r => r.id === active.id)
+    const newIndex = rows.findIndex(r => r.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+    onChange(arrayMove(rows, oldIndex, newIndex))
+  }
+
+  function setRowColumns(rowId: string, columns: Column[]) {
+    onChange(rows.map(r => (r.id === rowId ? { ...r, columns } : r)))
+  }
+
+  /**
+   * Ajusta o número de colunas de uma linha. Ao REDUZIR, os blocos das colunas removidas
+   * são despejados na última coluna que permanece (nada se perde). Ao AUMENTAR, anexa
+   * colunas vazias ao final.
+   */
+  function setColumnCount(rowId: string, target: number) {
+    onChange(
+      rows.map(r => {
+        if (r.id !== rowId) return r
+        const cur = r.columns.length
+        if (target === cur) return r
+        if (target > cur) {
+          const extra = Array.from({ length: target - cur }, makeColumn)
+          return { ...r, columns: [...r.columns, ...extra] }
+        }
+        // reduzir: mantém as `target` primeiras; move blocos das demais para a última mantida.
+        const kept = r.columns.slice(0, target).map(c => ({ ...c, blocks: [...c.blocks] }))
+        const dropped = r.columns.slice(target)
+        const last = kept[kept.length - 1]
+        for (const c of dropped) last.blocks.push(...c.blocks)
+        return { ...r, columns: kept }
+      }),
+    )
+  }
+
+  function removeRow(rowId: string) {
+    onChange(rows.filter(r => r.id !== rowId))
+  }
+
+  function addRow() {
+    onChange([...rows, makeRow(1)])
+  }
+
+  return (
+    <div className="space-y-4">
+      {rows.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-gray-300 px-4 py-8 text-center text-sm text-gray-500">
+          Nenhuma linha ainda. Adicione a primeira abaixo.
+        </p>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={rows.map(r => r.id)} strategy={verticalListSortingStrategy}>
+            <div className="space-y-4">
+              {rows.map((row, idx) => (
+                <SortableRow
+                  key={row.id}
+                  row={row}
+                  index={idx}
+                  onColumns={cols => setRowColumns(row.id, cols)}
+                  onColumnCount={n => setColumnCount(row.id, n)}
+                  onRemove={() => removeRow(row.id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <div className="border-t border-gray-200 pt-4">
+        <Button variant="secondary" size="sm" onClick={addRow}>
+          + Adicionar linha
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function DragHandleIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor" aria-hidden="true">
+      <circle cx="9" cy="6" r="1.5" />
+      <circle cx="15" cy="6" r="1.5" />
+      <circle cx="9" cy="12" r="1.5" />
+      <circle cx="15" cy="12" r="1.5" />
+      <circle cx="9" cy="18" r="1.5" />
+      <circle cx="15" cy="18" r="1.5" />
+    </svg>
+  )
+}
+
+function SortableRow({
+  row,
+  index,
+  onColumns,
+  onColumnCount,
+  onRemove,
+}: {
+  row: Row
+  index: number
+  onColumns: (cols: Column[]) => void
+  onColumnCount: (n: number) => void
+  onRemove: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.id,
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-xl border border-gray-300 bg-white shadow-sm ${
+        isDragging ? 'opacity-60 ring-2 ring-iasd-accent' : ''
+      }`}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-100 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Arrastar para reordenar a linha"
+            className="cursor-grab touch-none text-gray-400 hover:text-iasd-dark active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+          >
+            <DragHandleIcon />
+          </button>
+          <span className="text-sm font-semibold text-iasd-dark">Linha {index + 1}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-1.5 text-xs text-gray-600">
+            Colunas:
+            <div className="flex overflow-hidden rounded-md border border-gray-300">
+              {COLUMN_COUNTS.map(n => {
+                const active = row.columns.length === n
+                return (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => onColumnCount(n)}
+                    aria-pressed={active}
+                    className={`px-2.5 py-1 text-sm ${
+                      active
+                        ? 'bg-iasd-accent font-medium text-white'
+                        : 'bg-white text-gray-600 hover:bg-gray-50'
+                    }`}
+                  >
+                    {n}
+                  </button>
+                )
+              })}
+            </div>
+          </label>
+          <button
+            type="button"
+            onClick={onRemove}
+            aria-label="Remover linha"
+            className="rounded px-2 py-1 text-sm text-red-600 hover:bg-red-50"
+          >
+            Remover linha
+          </button>
+        </div>
+      </div>
+      <div className="p-3">
+        <ColumnEditor columns={row.columns} onChange={onColumns} />
+      </div>
+    </div>
+  )
+}

--- a/src/painel/components/blocks/GalleryEditor.tsx
+++ b/src/painel/components/blocks/GalleryEditor.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { Button } from '@/painel/ui'
+import MediaPicker from '@/painel/components/MediaPicker'
+import type { GalleryBlock } from '@/schemas/boletim'
+
+interface Props {
+  block: GalleryBlock
+  onChange: (props: GalleryBlock['props']) => void
+}
+
+/** Editor de bloco de galeria: miniaturas selecionadas (removíveis) + escolher várias. */
+export default function GalleryEditor({ block, onChange }: Props) {
+  const [picking, setPicking] = useState(false)
+  const { mediaIds } = block.props
+
+  function remove(id: string) {
+    onChange({ mediaIds: mediaIds.filter(x => x !== id) })
+  }
+
+  function addSelected(ids: string[]) {
+    // mescla evitando duplicatas, preservando a ordem existente
+    const merged = [...mediaIds]
+    for (const id of ids) if (!merged.includes(id)) merged.push(id)
+    onChange({ mediaIds: merged })
+  }
+
+  return (
+    <div className="space-y-3">
+      {mediaIds.length > 0 ? (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
+          {mediaIds.map(id => (
+            <div
+              key={id}
+              className="group relative aspect-square overflow-hidden rounded-lg border border-gray-200 bg-gray-100"
+            >
+              <img src={`/media/${id}`} alt="" className="h-full w-full object-cover" />
+              <button
+                type="button"
+                onClick={() => remove(id)}
+                aria-label="Remover imagem"
+                className="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-full bg-black/50 text-white opacity-0 transition-opacity hover:bg-red-600 group-hover:opacity-100 [@media(hover:none)]:opacity-100"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">Nenhuma imagem na galeria.</p>
+      )}
+
+      <Button variant="secondary" size="sm" onClick={() => setPicking(true)}>
+        Escolher imagens
+      </Button>
+
+      <MediaPicker
+        open={picking}
+        onClose={() => setPicking(false)}
+        multiple
+        onSelect={addSelected}
+      />
+    </div>
+  )
+}

--- a/src/painel/components/blocks/GalleryEditor.tsx
+++ b/src/painel/components/blocks/GalleryEditor.tsx
@@ -33,7 +33,7 @@ export default function GalleryEditor({ block, onChange }: Props) {
               key={id}
               className="group relative aspect-square overflow-hidden rounded-lg border border-gray-200 bg-gray-100"
             >
-              <img src={`/media/${id}`} alt="" className="h-full w-full object-cover" />
+              <img src={`/media/${id}/thumb`} alt="" className="h-full w-full object-cover" />
               <button
                 type="button"
                 onClick={() => remove(id)}

--- a/src/painel/components/blocks/HeadingEditor.tsx
+++ b/src/painel/components/blocks/HeadingEditor.tsx
@@ -1,0 +1,33 @@
+import { Field, Input, Select } from '@/painel/ui'
+import type { HeadingBlock } from '@/schemas/boletim'
+
+interface Props {
+  block: HeadingBlock
+  onChange: (props: HeadingBlock['props']) => void
+}
+
+/** Editor de bloco de título: texto + nível (2/3). */
+export default function HeadingEditor({ block, onChange }: Props) {
+  const { text, level } = block.props
+  return (
+    <div className="grid gap-3 sm:grid-cols-[1fr_8rem]">
+      <Field label="Título">
+        <Input
+          value={text}
+          maxLength={200}
+          placeholder="Texto do título…"
+          onChange={e => onChange({ text: e.target.value, level })}
+        />
+      </Field>
+      <Field label="Nível">
+        <Select
+          value={String(level)}
+          onChange={e => onChange({ text, level: Number(e.target.value) as 2 | 3 })}
+        >
+          <option value="2">Maior (H2)</option>
+          <option value="3">Menor (H3)</option>
+        </Select>
+      </Field>
+    </div>
+  )
+}

--- a/src/painel/components/blocks/ImageEditor.tsx
+++ b/src/painel/components/blocks/ImageEditor.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { Button, Field, Input } from '@/painel/ui'
+import MediaPicker from '@/painel/components/MediaPicker'
+import type { ImageBlock } from '@/schemas/boletim'
+
+interface Props {
+  block: ImageBlock
+  onChange: (props: ImageBlock['props']) => void
+}
+
+/** Editor de bloco de imagem: miniatura + escolher da biblioteca + texto alternativo. */
+export default function ImageEditor({ block, onChange }: Props) {
+  const [picking, setPicking] = useState(false)
+  const { mediaId, alt } = block.props
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-3">
+        <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+          {mediaId ? (
+            <img
+              src={`/media/${mediaId}`}
+              alt={alt || 'Imagem selecionada'}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">
+              Sem imagem
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <Button variant="secondary" size="sm" onClick={() => setPicking(true)}>
+            {mediaId ? 'Trocar imagem' : 'Escolher imagem'}
+          </Button>
+        </div>
+      </div>
+
+      <Field label="Texto alternativo (acessibilidade)">
+        <Input
+          value={alt}
+          maxLength={200}
+          placeholder="Descreva a imagem…"
+          onChange={e => onChange({ mediaId, alt: e.target.value })}
+        />
+      </Field>
+
+      <MediaPicker
+        open={picking}
+        onClose={() => setPicking(false)}
+        onSelect={id => onChange({ mediaId: id, alt })}
+      />
+    </div>
+  )
+}

--- a/src/painel/components/blocks/ImageEditor.tsx
+++ b/src/painel/components/blocks/ImageEditor.tsx
@@ -15,25 +15,18 @@ export default function ImageEditor({ block, onChange }: Props) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-start gap-3">
-        <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
-          {mediaId ? (
-            <img
-              src={`/media/${mediaId}/thumb`}
-              alt={alt || 'Imagem selecionada'}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">
-              Sem imagem
-            </div>
-          )}
-        </div>
-        <div className="flex flex-col gap-2">
-          <Button variant="secondary" size="sm" onClick={() => setPicking(true)}>
-            {mediaId ? 'Trocar imagem' : 'Escolher imagem'}
-          </Button>
-        </div>
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+        {mediaId ? (
+          <img
+            src={`/media/${mediaId}`}
+            alt={alt || 'Imagem selecionada'}
+            className="max-h-80 w-full object-contain"
+          />
+        ) : (
+          <div className="flex h-48 w-full items-center justify-center text-sm text-gray-400">
+            Nenhuma imagem selecionada
+          </div>
+        )}
       </div>
 
       <Field label="Texto alternativo (acessibilidade)">
@@ -44,6 +37,10 @@ export default function ImageEditor({ block, onChange }: Props) {
           onChange={e => onChange({ mediaId, alt: e.target.value })}
         />
       </Field>
+
+      <Button variant="secondary" size="sm" onClick={() => setPicking(true)}>
+        {mediaId ? 'Trocar imagem' : 'Escolher imagem'}
+      </Button>
 
       <MediaPicker
         open={picking}

--- a/src/painel/components/blocks/ImageEditor.tsx
+++ b/src/painel/components/blocks/ImageEditor.tsx
@@ -19,7 +19,7 @@ export default function ImageEditor({ block, onChange }: Props) {
         <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
           {mediaId ? (
             <img
-              src={`/media/${mediaId}`}
+              src={`/media/${mediaId}/thumb`}
               alt={alt || 'Imagem selecionada'}
               className="h-full w-full object-cover"
             />

--- a/src/painel/components/blocks/TextBlockEditor.tsx
+++ b/src/painel/components/blocks/TextBlockEditor.tsx
@@ -1,16 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useEditor, EditorContent, type Editor } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-import Link from '@tiptap/extension-link'
+import { boletimTextExtensions as extensions } from '@/components/boletim/tiptap-extensions'
 import type { TipTapDoc } from '@/schemas/boletim'
-
-// IMPORTANTE: este conjunto de extensões deve bater EXATAMENTE com o do renderer
-// (src/components/boletim/blocks/TextBlock.tsx). Caso contrário, o texto salvo
-// pode renderizar diferente do que foi editado.
-const extensions = [
-  StarterKit,
-  Link.configure({ HTMLAttributes: { rel: 'noopener nofollow', target: '_blank' } }),
-]
 
 interface Props {
   /** doc TipTap inicial (props.doc do bloco). */
@@ -83,26 +74,71 @@ function ToolbarButton({
 }
 
 function Toolbar({ editor }: { editor: Editor }) {
-  const [linkInput, setLinkInput] = useState<string | null>(null)
+  const [linkOpen, setLinkOpen] = useState(false)
+  const [linkUrl, setLinkUrl] = useState('')
+  const [linkText, setLinkText] = useState('')
 
-  function applyLink() {
-    const href = (linkInput ?? '').trim()
-    if (!href) {
-      editor.chain().focus().extendMarkRange('link').unsetLink().run()
-    } else {
-      const normalized = /^https?:\/\//i.test(href) ? href : `https://${href}`
-      editor.chain().focus().extendMarkRange('link').setLink({ href: normalized }).run()
-    }
-    setLinkInput(null)
+  /** Abre o popover de link: pré-preenche o texto com a seleção e a URL com o link atual. */
+  function startLink() {
+    const { from, to } = editor.state.selection
+    const selectedText = editor.state.doc.textBetween(from, to, ' ')
+    const currentHref = editor.getAttributes('link').href as string | undefined
+    setLinkText(selectedText)
+    setLinkUrl(currentHref ?? '')
+    setLinkOpen(true)
   }
 
-  function startLink() {
-    const current = editor.getAttributes('link').href as string | undefined
-    setLinkInput(current ?? '')
+  function applyLink() {
+    const raw = linkUrl.trim()
+    if (!raw) {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run()
+      setLinkOpen(false)
+      return
+    }
+    const href = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`
+    const text = linkText.trim()
+    const { from, to } = editor.state.selection
+    const selectedText = editor.state.doc.textBetween(from, to, ' ')
+    if (text && text !== selectedText) {
+      // Texto digitado diferente da seleção: substitui a seleção (ou insere no cursor) com ele.
+      editor.chain().focus().insertContent({ type: 'text', text, marks: [{ type: 'link', attrs: { href } }] }).run()
+    } else if (selectedText) {
+      // Mantém o texto selecionado e só aplica o link.
+      editor.chain().focus().extendMarkRange('link').setLink({ href }).run()
+    } else {
+      // Sem seleção e sem texto: usa a própria URL como texto do link.
+      editor.chain().focus().insertContent({ type: 'text', text: raw, marks: [{ type: 'link', attrs: { href } }] }).run()
+    }
+    setLinkOpen(false)
+  }
+
+  const blockStyle = editor.isActive('heading', { level: 1 })
+    ? 'h1'
+    : editor.isActive('heading', { level: 2 })
+      ? 'h2'
+      : editor.isActive('heading', { level: 3 })
+        ? 'h3'
+        : 'p'
+
+  function applyBlockStyle(value: string) {
+    if (value === 'p') editor.chain().focus().setParagraph().run()
+    else editor.chain().focus().setHeading({ level: Number(value[1]) as 1 | 2 | 3 }).run()
   }
 
   return (
     <div className="flex flex-wrap items-center gap-1 border-b border-gray-200 bg-gray-50 px-2 py-1.5">
+      <select
+        aria-label="Estilo do texto"
+        value={blockStyle}
+        onChange={e => applyBlockStyle(e.target.value)}
+        className="rounded border border-gray-300 bg-white px-1.5 py-1 text-sm text-iasd-dark focus:border-iasd-accent focus:outline-none"
+      >
+        <option value="p">Parágrafo</option>
+        <option value="h1">Título 1</option>
+        <option value="h2">Título 2</option>
+        <option value="h3">Título 3</option>
+      </select>
+      <span className="mx-1 h-5 w-px bg-gray-300" aria-hidden="true" />
       <ToolbarButton
         label="Negrito"
         active={editor.isActive('bold')}
@@ -145,38 +181,55 @@ function Toolbar({ editor }: { editor: Editor }) {
         </ToolbarButton>
       )}
 
-      {linkInput !== null && (
-        <div className="flex w-full items-center gap-2 pt-1.5">
-          <input
-            autoFocus
-            type="url"
-            value={linkInput}
-            placeholder="https://exemplo.com"
-            onChange={e => setLinkInput(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                applyLink()
-              } else if (e.key === 'Escape') {
-                setLinkInput(null)
-              }
-            }}
-            className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm focus:border-iasd-accent focus:outline-none focus:ring-1 focus:ring-iasd-accent/40"
-          />
-          <button
-            type="button"
-            onClick={applyLink}
-            className="rounded bg-iasd-dark px-3 py-1 text-sm font-medium text-white hover:bg-iasd-accent"
-          >
-            Aplicar
-          </button>
-          <button
-            type="button"
-            onClick={() => setLinkInput(null)}
-            className="rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-200"
-          >
-            Cancelar
-          </button>
+      {linkOpen && (
+        <div className="mt-1.5 w-full rounded-md border border-gray-200 bg-white p-2">
+          <div className="flex flex-col gap-2">
+            <label className="flex flex-col gap-1 text-xs font-medium text-gray-600">
+              Texto do link
+              <input
+                autoFocus
+                type="text"
+                value={linkText}
+                placeholder="Ex.: clique aqui (vazio = usa a URL)"
+                onChange={e => setLinkText(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                  else if (e.key === 'Escape') setLinkOpen(false)
+                }}
+                className="rounded border border-gray-300 px-2 py-1 text-sm font-normal text-gray-800 focus:border-iasd-accent focus:outline-none focus:ring-1 focus:ring-iasd-accent/40"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-gray-600">
+              URL do link
+              <input
+                type="url"
+                value={linkUrl}
+                placeholder="https://exemplo.com"
+                onChange={e => setLinkUrl(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') { e.preventDefault(); applyLink() }
+                  else if (e.key === 'Escape') setLinkOpen(false)
+                }}
+                className="rounded border border-gray-300 px-2 py-1 text-sm font-normal text-gray-800 focus:border-iasd-accent focus:outline-none focus:ring-1 focus:ring-iasd-accent/40"
+              />
+            </label>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setLinkOpen(false)}
+                className="rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-200"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={applyLink}
+                className="rounded bg-iasd-dark px-3 py-1 text-sm font-medium text-white hover:bg-iasd-accent"
+              >
+                Aplicar
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/painel/components/blocks/TextBlockEditor.tsx
+++ b/src/painel/components/blocks/TextBlockEditor.tsx
@@ -38,7 +38,7 @@ export default function TextBlockEditor({ doc, onChange }: Props) {
     if (!editor) return
     const incoming = doc && Object.keys(doc).length > 0 ? doc : { type: 'doc', content: [] }
     if (JSON.stringify(incoming) !== JSON.stringify(editor.getJSON())) {
-      editor.commands.setContent(incoming as Parameters<typeof editor.commands.setContent>[0], { emitUpdate: false })
+      editor.commands.setContent(incoming as Parameters<typeof editor.commands.setContent>[0], false)
     }
   }, [doc, editor])
 

--- a/src/painel/components/blocks/TextBlockEditor.tsx
+++ b/src/painel/components/blocks/TextBlockEditor.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useEditor, EditorContent, type Editor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import type { TipTapDoc } from '@/schemas/boletim'
+
+// IMPORTANTE: este conjunto de extensões deve bater EXATAMENTE com o do renderer
+// (src/components/boletim/blocks/TextBlock.tsx). Caso contrário, o texto salvo
+// pode renderizar diferente do que foi editado.
+const extensions = [
+  StarterKit,
+  Link.configure({ HTMLAttributes: { rel: 'noopener nofollow', target: '_blank' } }),
+]
+
+interface Props {
+  /** doc TipTap inicial (props.doc do bloco). */
+  doc: TipTapDoc
+  onChange: (doc: TipTapDoc) => void
+}
+
+/** Editor de texto rico (TipTap) com barra de formatação on-brand. */
+export default function TextBlockEditor({ doc, onChange }: Props) {
+  const editor = useEditor({
+    extensions,
+    content: doc && Object.keys(doc).length > 0 ? doc : undefined,
+    onUpdate: ({ editor }) => onChange(editor.getJSON() as TipTapDoc),
+    editorProps: {
+      attributes: {
+        class:
+          'boletim-prose font-sans text-base leading-relaxed text-gray-800 min-h-[7rem] focus:outline-none',
+      },
+    },
+  })
+
+  if (!editor) return null
+
+  return (
+    <div className="rounded-lg border border-gray-300 focus-within:border-iasd-accent focus-within:ring-2 focus-within:ring-iasd-accent/40">
+      <Toolbar editor={editor} />
+      <div className="px-3 py-2">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  )
+}
+
+function ToolbarButton({
+  active,
+  onClick,
+  label,
+  children,
+}: {
+  active?: boolean
+  onClick: () => void
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      onMouseDown={e => e.preventDefault()}
+      onClick={onClick}
+      className={`min-w-[2rem] rounded px-2 py-1 text-sm font-medium transition-colors ${
+        active ? 'bg-iasd-dark text-white' : 'text-iasd-dark hover:bg-gray-200'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Toolbar({ editor }: { editor: Editor }) {
+  const [linkInput, setLinkInput] = useState<string | null>(null)
+
+  function applyLink() {
+    const href = (linkInput ?? '').trim()
+    if (!href) {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run()
+    } else {
+      const normalized = /^https?:\/\//i.test(href) ? href : `https://${href}`
+      editor.chain().focus().extendMarkRange('link').setLink({ href: normalized }).run()
+    }
+    setLinkInput(null)
+  }
+
+  function startLink() {
+    const current = editor.getAttributes('link').href as string | undefined
+    setLinkInput(current ?? '')
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 border-b border-gray-200 bg-gray-50 px-2 py-1.5">
+      <ToolbarButton
+        label="Negrito"
+        active={editor.isActive('bold')}
+        onClick={() => editor.chain().focus().toggleBold().run()}
+      >
+        <strong>B</strong>
+      </ToolbarButton>
+      <ToolbarButton
+        label="Itálico"
+        active={editor.isActive('italic')}
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+      >
+        <em>I</em>
+      </ToolbarButton>
+      <span className="mx-1 h-5 w-px bg-gray-300" aria-hidden="true" />
+      <ToolbarButton
+        label="Lista com marcadores"
+        active={editor.isActive('bulletList')}
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+      >
+        • Lista
+      </ToolbarButton>
+      <ToolbarButton
+        label="Lista numerada"
+        active={editor.isActive('orderedList')}
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+      >
+        1. Lista
+      </ToolbarButton>
+      <span className="mx-1 h-5 w-px bg-gray-300" aria-hidden="true" />
+      <ToolbarButton label="Inserir/editar link" active={editor.isActive('link')} onClick={startLink}>
+        🔗 Link
+      </ToolbarButton>
+      {editor.isActive('link') && (
+        <ToolbarButton
+          label="Remover link"
+          onClick={() => editor.chain().focus().extendMarkRange('link').unsetLink().run()}
+        >
+          ⊘ Tirar link
+        </ToolbarButton>
+      )}
+
+      {linkInput !== null && (
+        <div className="flex w-full items-center gap-2 pt-1.5">
+          <input
+            autoFocus
+            type="url"
+            value={linkInput}
+            placeholder="https://exemplo.com"
+            onChange={e => setLinkInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                applyLink()
+              } else if (e.key === 'Escape') {
+                setLinkInput(null)
+              }
+            }}
+            className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm focus:border-iasd-accent focus:outline-none focus:ring-1 focus:ring-iasd-accent/40"
+          />
+          <button
+            type="button"
+            onClick={applyLink}
+            className="rounded bg-iasd-dark px-3 py-1 text-sm font-medium text-white hover:bg-iasd-accent"
+          >
+            Aplicar
+          </button>
+          <button
+            type="button"
+            onClick={() => setLinkInput(null)}
+            className="rounded px-2 py-1 text-sm text-gray-600 hover:bg-gray-200"
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/painel/components/blocks/TextBlockEditor.tsx
+++ b/src/painel/components/blocks/TextBlockEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useEditor, EditorContent, type Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
@@ -31,6 +31,16 @@ export default function TextBlockEditor({ doc, onChange }: Props) {
       },
     },
   })
+
+  // Re-hidrata se o doc vier diferente de fora (ex.: após salvar/normalizar no servidor).
+  // Não reseta a cada tecla: só aplica quando o doc externo realmente diverge do atual.
+  useEffect(() => {
+    if (!editor) return
+    const incoming = doc && Object.keys(doc).length > 0 ? doc : { type: 'doc', content: [] }
+    if (JSON.stringify(incoming) !== JSON.stringify(editor.getJSON())) {
+      editor.commands.setContent(incoming as Parameters<typeof editor.commands.setContent>[0], { emitUpdate: false })
+    }
+  }, [doc, editor])
 
   if (!editor) return null
 

--- a/src/painel/components/blocks/VideoEditor.tsx
+++ b/src/painel/components/blocks/VideoEditor.tsx
@@ -13,7 +13,8 @@ interface Props {
  */
 export default function VideoEditor({ block, onChange }: Props) {
   const { youtubeId } = block.props
-  const [draft, setDraft] = useState('')
+  // Mostra o link atual ao reabrir (para edição), em vez de campo vazio.
+  const [draft, setDraft] = useState(youtubeId ? `https://youtu.be/${youtubeId}` : '')
   const [error, setError] = useState<string | null>(null)
 
   function commit(value: string) {
@@ -28,7 +29,6 @@ export default function VideoEditor({ block, onChange }: Props) {
       return
     }
     setError(null)
-    setDraft('')
     onChange({ youtubeId: id })
   }
 

--- a/src/painel/components/blocks/VideoEditor.tsx
+++ b/src/painel/components/blocks/VideoEditor.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Field, Input } from '@/painel/ui'
+import { extractYouTubeId, type VideoBlock } from '@/schemas/boletim'
+
+interface Props {
+  block: VideoBlock
+  onChange: (props: VideoBlock['props']) => void
+}
+
+/**
+ * Editor de bloco de vídeo: URL do YouTube → extractYouTubeId.
+ * Link inválido mostra erro inline e não é armazenado (CA-09).
+ */
+export default function VideoEditor({ block, onChange }: Props) {
+  const { youtubeId } = block.props
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  function commit(value: string) {
+    const v = value.trim()
+    if (!v) {
+      setError(null)
+      return
+    }
+    const id = extractYouTubeId(v)
+    if (!id) {
+      setError('Link do YouTube inválido')
+      return
+    }
+    setError(null)
+    setDraft('')
+    onChange({ youtubeId: id })
+  }
+
+  return (
+    <div className="space-y-3">
+      <Field label="Link do YouTube" error={error ?? undefined}>
+        <Input
+          type="url"
+          value={draft}
+          placeholder="https://www.youtube.com/watch?v=…"
+          onChange={e => {
+            setDraft(e.target.value)
+            if (error) setError(null)
+          }}
+          onBlur={e => commit(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              commit((e.target as HTMLInputElement).value)
+            }
+          }}
+        />
+      </Field>
+
+      {youtubeId && (
+        <div className="space-y-2">
+          <p className="text-xs text-green-700">Vídeo definido: {youtubeId}</p>
+          <div className="aspect-video w-full max-w-md overflow-hidden rounded-lg bg-black">
+            <iframe
+              src={`https://www.youtube.com/embed/${youtubeId}`}
+              title="Pré-visualização do vídeo"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="h-full w-full"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/painel/nav-config.tsx
+++ b/src/painel/nav-config.tsx
@@ -22,6 +22,7 @@ const I = {
   users: 'M16 14a4 4 0 10-8 0M12 7a3 3 0 100-6 3 3 0 000 6M3 20a6 6 0 0118 0',
   settings: 'M12 15a3 3 0 100-6 3 3 0 000 6M19 12a7 7 0 00-.1-1l2-1.6-2-3.4-2.4 1a7 7 0 00-1.7-1L14.5 2h-5l-.3 2.6a7 7 0 00-1.7 1l-2.4-1-2 3.4L2.1 11a7 7 0 000 2l-2 1.6 2 3.4 2.4-1a7 7 0 001.7 1l.3 2.6h5l.3-2.6a7 7 0 001.7-1l2.4 1 2-3.4-2-1.6a7 7 0 00.1-1z',
   image: 'M3 5h18v14H3zM3 15l5-5 4 4 3-3 6 6',
+  boletins: 'M19 20H6a2 2 0 01-2-2V4h12v14a2 2 0 002 2zm0 0a2 2 0 002-2V8h-3M8 8h6M8 12h6M8 16h4',
 }
 
 export const NAV: NavEntry[] = [
@@ -34,5 +35,6 @@ export const NAV: NavEntry[] = [
     ],
   },
   { key: 'midia', label: 'Mídia', icon: icon(I.image), to: '/painel/midia', perm: 'media:manage' },
+  { key: 'boletins', label: 'Boletins', icon: icon(I.boletins), to: '/painel/boletins', perm: 'boletim:write' },
   { key: 'configuracoes', label: 'Configurações', icon: icon(I.settings), to: '/painel/configuracoes' },
 ]

--- a/src/painel/pages/BoletimEditor.tsx
+++ b/src/painel/pages/BoletimEditor.tsx
@@ -93,32 +93,39 @@ export default function BoletimEditor() {
     load()
   }, [load])
 
-  async function handleSave() {
-    setMsg(null)
-    // Validação client-side (CA-07): título não-vazio E ao menos um bloco.
+  /**
+   * Valida (CA-07) e persiste o estado atual. Retorna true se salvou. Define msg de erro
+   * quando a validação falha; não mostra msg de sucesso (quem chama decide).
+   */
+  async function persist(): Promise<boolean> {
     if (!title.trim()) {
       setMsg({ kind: 'err', text: 'Informe um título para o boletim.' })
-      return
+      return false
     }
     if (contentIsEmpty(rows)) {
       setMsg({ kind: 'err', text: 'Adicione ao menos um bloco de conteúdo.' })
-      return
+      return false
     }
     const incomplete = findIncompleteBlock(rows)
     if (incomplete) {
       setMsg({ kind: 'err', text: `Há um bloco de ${BLOCK_LABELS[incomplete.type]} incompleto. Preencha-o ou remova-o.` })
-      return
+      return false
     }
+    const updated = await updateBoletim(id, {
+      title: title.trim(),
+      summary: summary.trim() || null,
+      coverMediaId,
+      content: rows,
+    })
+    hydrate(updated)
+    return true
+  }
+
+  async function handleSave() {
+    setMsg(null)
     setSaving(true)
     try {
-      const updated = await updateBoletim(id, {
-        title: title.trim(),
-        summary: summary.trim() || null,
-        coverMediaId,
-        content: rows,
-      })
-      hydrate(updated)
-      setMsg({ kind: 'ok', text: 'Boletim salvo.' })
+      if (await persist()) setMsg({ kind: 'ok', text: 'Boletim salvo.' })
     } catch (e) {
       setMsg({ kind: 'err', text: (e as Error).message })
     } finally {
@@ -130,6 +137,9 @@ export default function BoletimEditor() {
     setMsg(null)
     setBusy(true)
     try {
+      // Salva o estado atual ANTES de publicar: a validação do servidor roda sobre o
+      // conteúdo persistido, então sem salvar publicaria a versão antiga (evita falso "incompleto").
+      if (!(await persist())) return
       const updated = await publishBoletim(id)
       hydrate(updated)
       setMsg({ kind: 'ok', text: 'Boletim publicado.' })

--- a/src/painel/pages/BoletimEditor.tsx
+++ b/src/painel/pages/BoletimEditor.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ensureCsrf } from '@/auth/auth-api'
+import {
+  getBoletim,
+  updateBoletim,
+  publishBoletim,
+  unpublishBoletim,
+  PublishIncompleteError,
+  type Boletim,
+} from '@/painel/boletim-api'
+import type { Block } from '@/schemas/boletim'
+import BlockList from '@/painel/components/BlockList'
+import MediaPicker from '@/painel/components/MediaPicker'
+import BulletinRenderer from '@/components/boletim/BulletinRenderer'
+import {
+  PageHeader,
+  Card,
+  Button,
+  Badge,
+  StatusBadge,
+  Chip,
+  Alert,
+  Field,
+  Input,
+  Textarea,
+  Spinner,
+  type Message,
+} from '@/painel/ui'
+
+const MISSING_LABELS: Record<string, string> = {
+  title: 'título',
+  content: 'conteúdo (ao menos um bloco)',
+  'summary/cover': 'resumo ou imagem de capa',
+}
+
+export default function BoletimEditor() {
+  const { id = '' } = useParams()
+  const navigate = useNavigate()
+
+  const [boletim, setBoletim] = useState<Boletim | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  // estado editável
+  const [title, setTitle] = useState('')
+  const [summary, setSummary] = useState('')
+  const [coverMediaId, setCoverMediaId] = useState<string | null>(null)
+  const [blocks, setBlocks] = useState<Block[]>([])
+
+  const [coverPicking, setCoverPicking] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [msg, setMsg] = useState<Message | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const hydrate = useCallback((b: Boletim) => {
+    setBoletim(b)
+    setTitle(b.title)
+    setSummary(b.summary ?? '')
+    setCoverMediaId(b.coverMediaId)
+    setBlocks(b.content)
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    await ensureCsrf()
+    try {
+      const b = await getBoletim(id)
+      hydrate(b)
+      setLoadError(null)
+    } catch (e) {
+      setLoadError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [id, hydrate])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  async function handleSave() {
+    setMsg(null)
+    // Validação client-side (CA-07): título não-vazio E ao menos um bloco.
+    if (!title.trim()) {
+      setMsg({ kind: 'err', text: 'Informe um título para o boletim.' })
+      return
+    }
+    if (blocks.length === 0) {
+      setMsg({ kind: 'err', text: 'Adicione ao menos um bloco de conteúdo.' })
+      return
+    }
+    setSaving(true)
+    try {
+      const updated = await updateBoletim(id, {
+        title: title.trim(),
+        summary: summary.trim() || null,
+        coverMediaId,
+        content: blocks,
+      })
+      hydrate(updated)
+      setMsg({ kind: 'ok', text: 'Boletim salvo.' })
+    } catch (e) {
+      setMsg({ kind: 'err', text: (e as Error).message })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handlePublish() {
+    setMsg(null)
+    setBusy(true)
+    try {
+      const updated = await publishBoletim(id)
+      hydrate(updated)
+      setMsg({ kind: 'ok', text: 'Boletim publicado.' })
+    } catch (e) {
+      if (e instanceof PublishIncompleteError) {
+        const labels = e.missing.map(k => MISSING_LABELS[k] ?? k).join(', ')
+        setMsg({ kind: 'err', text: `Não foi possível publicar. Faltando: ${labels}.` })
+      } else {
+        setMsg({ kind: 'err', text: (e as Error).message })
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleUnpublish() {
+    setMsg(null)
+    setBusy(true)
+    try {
+      const updated = await unpublishBoletim(id)
+      hydrate(updated)
+      setMsg({ kind: 'ok', text: 'Boletim despublicado.' })
+    } catch (e) {
+      setMsg({ kind: 'err', text: (e as Error).message })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function copyLink() {
+    if (!boletim?.publicUrl) return
+    try {
+      await navigator.clipboard.writeText(boletim.publicUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setMsg({ kind: 'err', text: 'Não foi possível copiar o link.' })
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-24">
+        <Spinner className="w-8 h-8" />
+      </div>
+    )
+  }
+
+  if (loadError || !boletim) {
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Boletim" />
+        <Alert kind="err">{loadError ?? 'Boletim não encontrado.'}</Alert>
+        <Button variant="secondary" onClick={() => navigate('/painel/boletins')}>
+          Voltar para a lista
+        </Button>
+      </div>
+    )
+  }
+
+  const published = boletim.status === 'published'
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Editar boletim"
+        subtitle={
+          <span className="inline-flex items-center gap-2">
+            <StatusBadge status={published ? 'active' : 'disabled'} />
+            {published && boletim.slug && (
+              <Badge color="blue">Link fixo: /boletins/{boletim.slug}</Badge>
+            )}
+          </span>
+        }
+        actions={
+          <Button variant="ghost" onClick={() => navigate('/painel/boletins')}>
+            Voltar
+          </Button>
+        }
+      />
+
+      {msg && <Alert message={msg} />}
+
+      {published && boletim.publicUrl && (
+        <Card title="Boletim publicado">
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600">
+              Link público:{' '}
+              <a
+                href={boletim.publicUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-iasd-accent underline"
+              >
+                {boletim.publicUrl}
+              </a>
+            </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button variant="secondary" size="sm" onClick={copyLink}>
+                {copied ? 'Link copiado!' : 'Copiar link'}
+              </Button>
+              <a
+                href={`https://wa.me/?text=${encodeURIComponent(
+                  `${boletim.title} — ${boletim.publicUrl}`,
+                )}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg border border-iasd-dark px-3 py-1.5 text-sm font-medium text-iasd-dark transition-colors hover:bg-gray-100"
+              >
+                Compartilhar no WhatsApp
+              </a>
+            </div>
+            <Chip>O link não muda ao editar o título (slug travado após publicação).</Chip>
+          </div>
+        </Card>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-6">
+          <Card title="Informações">
+            <div className="space-y-4">
+              <Field label="Título">
+                <Input
+                  value={title}
+                  maxLength={200}
+                  placeholder="Título do boletim"
+                  onChange={e => setTitle(e.target.value)}
+                />
+              </Field>
+              <Field label="Resumo (opcional)">
+                <Textarea
+                  value={summary}
+                  maxLength={500}
+                  rows={3}
+                  placeholder="Breve resumo exibido na lista e no compartilhamento."
+                  onChange={e => setSummary(e.target.value)}
+                />
+              </Field>
+              <Field label="Imagem de capa (opcional)">
+                <div className="flex items-start gap-3">
+                  <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+                    {coverMediaId ? (
+                      <img
+                        src={`/media/${coverMediaId}`}
+                        alt="Capa"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">
+                        Sem capa
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Button variant="secondary" size="sm" onClick={() => setCoverPicking(true)}>
+                      {coverMediaId ? 'Trocar capa' : 'Escolher capa'}
+                    </Button>
+                    {coverMediaId && (
+                      <Button variant="ghost" size="sm" onClick={() => setCoverMediaId(null)}>
+                        Remover capa
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <p className="mt-1 text-xs text-gray-500">
+                  Se vazia, ao salvar o sistema sugere a primeira imagem do conteúdo.
+                </p>
+              </Field>
+            </div>
+          </Card>
+
+          <Card title="Conteúdo">
+            <BlockList blocks={blocks} onChange={setBlocks} />
+          </Card>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Salvando…' : 'Salvar'}
+            </Button>
+            {published ? (
+              <Button variant="secondary" onClick={handleUnpublish} disabled={busy}>
+                Despublicar
+              </Button>
+            ) : (
+              <Button variant="secondary" onClick={handlePublish} disabled={busy}>
+                Publicar
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <Card title="Pré-visualização">
+            {blocks.length === 0 ? (
+              <p className="py-8 text-center text-sm text-gray-500">
+                Adicione blocos para ver a pré-visualização.
+              </p>
+            ) : (
+              <BulletinRenderer content={blocks} />
+            )}
+          </Card>
+        </div>
+      </div>
+
+      <MediaPicker
+        open={coverPicking}
+        onClose={() => setCoverPicking(false)}
+        onSelect={cid => setCoverMediaId(cid)}
+      />
+    </div>
+  )
+}

--- a/src/painel/pages/BoletimEditor.tsx
+++ b/src/painel/pages/BoletimEditor.tsx
@@ -6,11 +6,10 @@ import {
   updateBoletim,
   publishBoletim,
   unpublishBoletim,
-  PublishIncompleteError,
   type Boletim,
 } from '@/painel/boletim-api'
 import type { Block } from '@/schemas/boletim'
-import BlockList from '@/painel/components/BlockList'
+import BlockList, { BLOCK_LABELS } from '@/painel/components/BlockList'
 import MediaPicker from '@/painel/components/MediaPicker'
 import BulletinRenderer from '@/components/boletim/BulletinRenderer'
 import {
@@ -28,10 +27,14 @@ import {
   type Message,
 } from '@/painel/ui'
 
-const MISSING_LABELS: Record<string, string> = {
-  title: 'título',
-  content: 'conteúdo (ao menos um bloco)',
-  'summary/cover': 'resumo ou imagem de capa',
+/** Aponta o primeiro bloco incompleto (que o backend rejeitaria com 422 genérico). */
+function findIncompleteBlock(blocks: Block[]): Block | undefined {
+  return blocks.find(b =>
+    (b.type === 'heading' && !b.props.text.trim()) ||
+    (b.type === 'image' && !b.props.mediaId) ||
+    (b.type === 'gallery' && b.props.mediaIds.length === 0) ||
+    (b.type === 'video' && !b.props.youtubeId),
+  )
 }
 
 export default function BoletimEditor() {
@@ -91,6 +94,11 @@ export default function BoletimEditor() {
       setMsg({ kind: 'err', text: 'Adicione ao menos um bloco de conteúdo.' })
       return
     }
+    const incomplete = findIncompleteBlock(blocks)
+    if (incomplete) {
+      setMsg({ kind: 'err', text: `Há um bloco de ${BLOCK_LABELS[incomplete.type]} incompleto. Preencha-o ou remova-o.` })
+      return
+    }
     setSaving(true)
     try {
       const updated = await updateBoletim(id, {
@@ -116,12 +124,8 @@ export default function BoletimEditor() {
       hydrate(updated)
       setMsg({ kind: 'ok', text: 'Boletim publicado.' })
     } catch (e) {
-      if (e instanceof PublishIncompleteError) {
-        const labels = e.missing.map(k => MISSING_LABELS[k] ?? k).join(', ')
-        setMsg({ kind: 'err', text: `Não foi possível publicar. Faltando: ${labels}.` })
-      } else {
-        setMsg({ kind: 'err', text: (e as Error).message })
-      }
+      // PublishIncompleteError.message já vem formatado ("…Faltando: título, …").
+      setMsg({ kind: 'err', text: (e as Error).message })
     } finally {
       setBusy(false)
     }
@@ -255,7 +259,7 @@ export default function BoletimEditor() {
                   <div className="h-24 w-24 shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
                     {coverMediaId ? (
                       <img
-                        src={`/media/${coverMediaId}`}
+                        src={`/media/${coverMediaId}/thumb`}
                         alt="Capa"
                         className="h-full w-full object-cover"
                       />

--- a/src/painel/pages/BoletimEditor.tsx
+++ b/src/painel/pages/BoletimEditor.tsx
@@ -8,10 +8,10 @@ import {
   unpublishBoletim,
   type Boletim,
 } from '@/painel/boletim-api'
-import type { Block } from '@/schemas/boletim'
-import BlockList, { BLOCK_LABELS } from '@/painel/components/BlockList'
+import { contentIsEmpty, type Block, type Row } from '@/schemas/boletim'
+import { BLOCK_LABELS } from '@/painel/components/BlockList'
+import RowList from '@/painel/components/RowList'
 import MediaPicker from '@/painel/components/MediaPicker'
-import BulletinRenderer from '@/components/boletim/BulletinRenderer'
 import {
   PageHeader,
   Card,
@@ -27,14 +27,24 @@ import {
   type Message,
 } from '@/painel/ui'
 
-/** Aponta o primeiro bloco incompleto (que o backend rejeitaria com 422 genérico). */
-function findIncompleteBlock(blocks: Block[]): Block | undefined {
-  return blocks.find(b =>
+function isIncompleteBlock(b: Block): boolean {
+  return (
     (b.type === 'heading' && !b.props.text.trim()) ||
     (b.type === 'image' && !b.props.mediaId) ||
     (b.type === 'gallery' && b.props.mediaIds.length === 0) ||
-    (b.type === 'video' && !b.props.youtubeId),
+    (b.type === 'video' && !b.props.youtubeId)
   )
+}
+
+/** Aponta o primeiro bloco incompleto em qualquer linha/coluna (backend rejeitaria com 422). */
+function findIncompleteBlock(rows: Row[]): Block | undefined {
+  for (const row of rows) {
+    for (const col of row.columns) {
+      const b = col.blocks.find(isIncompleteBlock)
+      if (b) return b
+    }
+  }
+  return undefined
 }
 
 export default function BoletimEditor() {
@@ -49,7 +59,7 @@ export default function BoletimEditor() {
   const [title, setTitle] = useState('')
   const [summary, setSummary] = useState('')
   const [coverMediaId, setCoverMediaId] = useState<string | null>(null)
-  const [blocks, setBlocks] = useState<Block[]>([])
+  const [rows, setRows] = useState<Row[]>([])
 
   const [coverPicking, setCoverPicking] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -62,7 +72,7 @@ export default function BoletimEditor() {
     setTitle(b.title)
     setSummary(b.summary ?? '')
     setCoverMediaId(b.coverMediaId)
-    setBlocks(b.content)
+    setRows(b.content)
   }, [])
 
   const load = useCallback(async () => {
@@ -90,11 +100,11 @@ export default function BoletimEditor() {
       setMsg({ kind: 'err', text: 'Informe um título para o boletim.' })
       return
     }
-    if (blocks.length === 0) {
+    if (contentIsEmpty(rows)) {
       setMsg({ kind: 'err', text: 'Adicione ao menos um bloco de conteúdo.' })
       return
     }
-    const incomplete = findIncompleteBlock(blocks)
+    const incomplete = findIncompleteBlock(rows)
     if (incomplete) {
       setMsg({ kind: 'err', text: `Há um bloco de ${BLOCK_LABELS[incomplete.type]} incompleto. Preencha-o ou remova-o.` })
       return
@@ -105,7 +115,7 @@ export default function BoletimEditor() {
         title: title.trim(),
         summary: summary.trim() || null,
         coverMediaId,
-        content: blocks,
+        content: rows,
       })
       hydrate(updated)
       setMsg({ kind: 'ok', text: 'Boletim salvo.' })
@@ -233,8 +243,7 @@ export default function BoletimEditor() {
         </Card>
       )}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <div className="space-y-6">
+      <div className="space-y-6">
           <Card title="Informações">
             <div className="space-y-4">
               <Field label="Título">
@@ -288,12 +297,18 @@ export default function BoletimEditor() {
           </Card>
 
           <Card title="Conteúdo">
-            <BlockList blocks={blocks} onChange={setBlocks} />
+            <RowList rows={rows} onChange={setRows} />
           </Card>
 
           <div className="flex flex-wrap items-center gap-2">
             <Button onClick={handleSave} disabled={saving}>
               {saving ? 'Salvando…' : 'Salvar'}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => window.open(`/painel/boletins/${id}/preview`, '_blank')}
+            >
+              Pré-visualizar
             </Button>
             {published ? (
               <Button variant="secondary" onClick={handleUnpublish} disabled={busy}>
@@ -305,19 +320,7 @@ export default function BoletimEditor() {
               </Button>
             )}
           </div>
-        </div>
-
-        <div>
-          <Card title="Pré-visualização">
-            {blocks.length === 0 ? (
-              <p className="py-8 text-center text-sm text-gray-500">
-                Adicione blocos para ver a pré-visualização.
-              </p>
-            ) : (
-              <BulletinRenderer content={blocks} />
-            )}
-          </Card>
-        </div>
+          <Chip>A pré-visualização abre em nova aba e mostra a última versão salva.</Chip>
       </div>
 
       <MediaPicker

--- a/src/painel/pages/Boletins.tsx
+++ b/src/painel/pages/Boletins.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/painel/boletim-api'
 import {
   PageHeader, Button, Badge, Field, Input, Alert, EmptyState, Spinner, Modal, Pager,
-  Table, THead, EmptyRow, th, td,
+  Table, THead, th, td,
 } from '@/painel/ui'
 
 function formatDate(b: Boletim): string {
@@ -141,7 +141,6 @@ export default function Boletins() {
                 </td>
               </tr>
             ))}
-            {items.length === 0 && <EmptyRow colSpan={4}>Nenhum boletim.</EmptyRow>}
           </tbody>
         </Table>
       )}

--- a/src/painel/pages/Boletins.tsx
+++ b/src/painel/pages/Boletins.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ensureCsrf } from '@/auth/auth-api'
+import { usePagination, type PageInfo } from '@/painel/usePagination'
+import {
+  listBoletins, createBoletim, deleteBoletim, publishBoletim, unpublishBoletim,
+  type Boletim,
+} from '@/painel/boletim-api'
+import {
+  PageHeader, Button, Badge, Field, Input, Alert, EmptyState, Spinner, Modal, Pager,
+  Table, THead, EmptyRow, th, td,
+} from '@/painel/ui'
+
+function formatDate(b: Boletim): string {
+  const iso = b.status === 'published' && b.publishedAt ? b.publishedAt : b.updatedAt
+  return new Date(iso).toLocaleString('pt-BR')
+}
+
+function StatusBadge({ status }: { status: Boletim['status'] }) {
+  const published = status === 'published'
+  return (
+    <Badge color={published ? 'green' : 'gray'}>
+      <span className={`w-1.5 h-1.5 rounded-full ${published ? 'bg-green-500' : 'bg-gray-400'}`} />
+      {published ? 'Publicado' : 'Rascunho'}
+    </Badge>
+  )
+}
+
+export default function Boletins() {
+  const navigate = useNavigate()
+  const { page, limit, setPage } = usePagination()
+  const [items, setItems] = useState<Boletim[]>([])
+  const [info, setInfo] = useState<PageInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [toDelete, setToDelete] = useState<Boletim | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    await ensureCsrf()
+    try {
+      const body = await listBoletins(page, limit)
+      setError(null)
+      setItems(body.data)
+      setInfo(body.pagination)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [page, limit])
+
+  // debounce: recarrega 300ms após a última mudança de página
+  useEffect(() => {
+    setLoading(true)
+    const t = setTimeout(load, 300)
+    return () => clearTimeout(t)
+  }, [load])
+
+  async function togglePublish(b: Boletim) {
+    setBusyId(b.id)
+    setError(null)
+    try {
+      await ensureCsrf()
+      if (b.status === 'published') await unpublishBoletim(b.id)
+      else await publishBoletim(b.id)
+      await load()
+    } catch (e) {
+      // PublishIncompleteError.message já vem formatado ("…Faltando: título, …").
+      setError((e as Error).message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function copyLink(b: Boletim) {
+    if (!b.publicUrl) return
+    try {
+      await navigator.clipboard.writeText(b.publicUrl)
+      setCopiedId(b.id)
+      setTimeout(() => setCopiedId(c => (c === b.id ? null : c)), 2000)
+    } catch {
+      setError('Não foi possível copiar o link.')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Boletins"
+        actions={<Button onClick={() => setCreating(true)}>Novo boletim</Button>}
+      />
+
+      {error && <Alert kind="err">{error}</Alert>}
+
+      {loading ? (
+        <div className="flex justify-center py-16"><Spinner className="w-8 h-8" /></div>
+      ) : items.length === 0 ? (
+        <EmptyState title="Nenhum boletim" description="Crie o primeiro boletim para começar." />
+      ) : (
+        <Table>
+          <THead>
+            <tr>
+              <th className={th}>Título</th>
+              <th className={th}>Status</th>
+              <th className={th}>Atualizado</th>
+              <th className={th}></th>
+            </tr>
+          </THead>
+          <tbody>
+            {items.map(b => (
+              <tr key={b.id} className="border-t border-gray-100 hover:bg-gray-50 transition-colors">
+                <td className={td}>
+                  <button onClick={() => navigate(`/painel/boletins/${b.id}`)}
+                    className="text-iasd-accent hover:underline font-medium text-left">
+                    {b.title}
+                  </button>
+                </td>
+                <td className={td}><StatusBadge status={b.status} /></td>
+                <td className={`${td} text-gray-500`}>{formatDate(b)}</td>
+                <td className={td}>
+                  <div className="flex items-center justify-end gap-2 flex-wrap">
+                    <Button variant="secondary" size="sm" onClick={() => navigate(`/painel/boletins/${b.id}`)}>
+                      Editar
+                    </Button>
+                    <Button variant="secondary" size="sm" disabled={busyId === b.id}
+                      onClick={() => togglePublish(b)}>
+                      {b.status === 'published' ? 'Despublicar' : 'Publicar'}
+                    </Button>
+                    {b.status === 'published' && b.publicUrl && (
+                      <Button variant="ghost" size="sm" onClick={() => copyLink(b)}>
+                        {copiedId === b.id ? 'Link copiado!' : 'Copiar link'}
+                      </Button>
+                    )}
+                    <Button variant="danger" size="sm" onClick={() => setToDelete(b)}>
+                      Excluir
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && <EmptyRow colSpan={4}>Nenhum boletim.</EmptyRow>}
+          </tbody>
+        </Table>
+      )}
+
+      {!loading && info && <Pager info={info} onPage={setPage} />}
+
+      {creating && (
+        <CreateModal
+          onClose={() => setCreating(false)}
+          onCreated={created => navigate(`/painel/boletins/${created.id}`)}
+        />
+      )}
+
+      {toDelete && (
+        <Modal title="Excluir boletim" onClose={() => setToDelete(null)}>
+          <p className="text-sm text-gray-600 mb-4">
+            Remover <strong>{toDelete.title}</strong>? Esta ação não pode ser desfeita.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setToDelete(null)}>Cancelar</Button>
+            <Button variant="danger" onClick={async () => {
+              const target = toDelete
+              setToDelete(null)
+              try { await ensureCsrf(); await deleteBoletim(target.id); await load() }
+              catch (e) { setError((e as Error).message) }
+            }}>Excluir</Button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+function CreateModal({ onClose, onCreated }: { onClose: () => void; onCreated: (b: Boletim) => void }) {
+  const [title, setTitle] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  async function submit() {
+    const trimmed = title.trim()
+    if (!trimmed) { setErr('Informe um título.'); return }
+    setErr(null); setBusy(true)
+    try {
+      await ensureCsrf()
+      const created = await createBoletim(trimmed)
+      onCreated(created)
+    } catch (e) {
+      setErr((e as Error).message); setBusy(false)
+    }
+  }
+
+  return (
+    <Modal title="Novo boletim" onClose={onClose}>
+      <div className="space-y-4">
+        <Field label="Título">
+          <Input autoFocus value={title} disabled={busy}
+            onChange={e => setTitle(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') submit() }}
+            placeholder="Ex.: Boletim de Sábado" />
+        </Field>
+        {err && <Alert kind="err">{err}</Alert>}
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={busy}>Cancelar</Button>
+          <Button onClick={submit} disabled={busy}>{busy ? 'Criando…' : 'Criar'}</Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/painel/pages/Dashboard.tsx
+++ b/src/painel/pages/Dashboard.tsx
@@ -27,6 +27,13 @@ const ShieldIcon = () => (
   </svg>
 )
 
+const NewspaperIcon = () => (
+  <svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor"
+    strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M19 20H6a2 2 0 0 1-2-2V4h12v14a2 2 0 0 0 2 2zm0 0a2 2 0 0 0 2-2V8h-3M8 8h6M8 12h6M8 16h4" />
+  </svg>
+)
+
 const CogIcon = () => (
   <svg viewBox="0 0 24 24" className="w-6 h-6" fill="none" stroke="currentColor"
     strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -52,6 +59,14 @@ interface Shortcut {
 }
 
 const SHORTCUTS: Shortcut[] = [
+  {
+    key: 'boletins',
+    to: '/painel/boletins',
+    label: 'Boletins',
+    description: 'Crie e publique o boletim informativo.',
+    icon: <NewspaperIcon />,
+    perm: 'boletim:write',
+  },
   {
     key: 'usuarios',
     to: '/painel/usuarios',

--- a/src/schemas/boletim.ts
+++ b/src/schemas/boletim.ts
@@ -39,6 +39,52 @@ export type Block = HeadingBlock | TextBlock | ImageBlock | GalleryBlock | Video
 
 export type BlockType = Block['type']
 
+// Layout em linhas/colunas: o conteúdo é uma lista ordenada de LINHAS; cada linha tem
+// 1..4 COLUNAS; cada coluna guarda uma lista ordenada de BLOCOS.
+export interface Column {
+  id: string
+  blocks: Block[]
+}
+
+export interface Row {
+  id: string
+  columns: Column[]
+}
+
+/** Cria um bloco vazio do tipo pedido, com id novo e props padrão sensatas. */
+export function makeBlock(type: BlockType): Block {
+  const id = crypto.randomUUID()
+  switch (type) {
+    case 'heading':
+      return { id, type, props: { text: '', level: 2 } }
+    case 'text':
+      return { id, type, props: { doc: {} } }
+    case 'image':
+      return { id, type, props: { mediaId: '', alt: '' } }
+    case 'gallery':
+      return { id, type, props: { mediaIds: [] } }
+    case 'video':
+      return { id, type, props: { youtubeId: '' } }
+  }
+}
+
+/** Cria uma coluna vazia, com id novo. */
+export function makeColumn(): Column {
+  return { id: crypto.randomUUID(), blocks: [] }
+}
+
+/** Cria uma linha com `columnCount` colunas vazias (limitado a 1..4). */
+export function makeRow(columnCount = 1): Row {
+  const n = Math.min(4, Math.max(1, columnCount))
+  return { id: crypto.randomUUID(), columns: Array.from({ length: n }, makeColumn) }
+}
+
+/** Conteúdo "vazio": sem linhas, ou toda coluna de toda linha sem blocos. */
+export function contentIsEmpty(rows: Row[]): boolean {
+  if (!Array.isArray(rows) || rows.length === 0) return true
+  return rows.every((row) => row.columns.every((col) => col.blocks.length === 0))
+}
+
 /** Extrai o videoId de uma URL do YouTube (watch, youtu.be, embed, shorts) ou aceita um id puro. */
 export function extractYouTubeId(input: string): string | null {
   const s = input.trim()

--- a/src/schemas/boletim.ts
+++ b/src/schemas/boletim.ts
@@ -1,0 +1,58 @@
+// Espelho client dos tipos de bloco do boletim.
+// FONTE DA VERDADE: server/modules/boletins/dto/block.schema.ts — manter em sincronia.
+// (Convenção do projeto: schemas Zod duplicados client/server.)
+
+/** Documento TipTap/ProseMirror serializado em JSON. */
+export type TipTapDoc = Record<string, unknown>
+
+export interface HeadingBlock {
+  id: string
+  type: 'heading'
+  props: { text: string; level: 2 | 3 }
+}
+
+export interface TextBlock {
+  id: string
+  type: 'text'
+  props: { doc: TipTapDoc }
+}
+
+export interface ImageBlock {
+  id: string
+  type: 'image'
+  props: { mediaId: string; alt: string }
+}
+
+export interface GalleryBlock {
+  id: string
+  type: 'gallery'
+  props: { mediaIds: string[] }
+}
+
+export interface VideoBlock {
+  id: string
+  type: 'video'
+  props: { youtubeId: string }
+}
+
+export type Block = HeadingBlock | TextBlock | ImageBlock | GalleryBlock | VideoBlock
+
+export type BlockType = Block['type']
+
+/** Extrai o videoId de uma URL do YouTube (watch, youtu.be, embed, shorts) ou aceita um id puro. */
+export function extractYouTubeId(input: string): string | null {
+  const s = input.trim()
+  // já é um id puro (11 chars base64url)
+  if (/^[a-zA-Z0-9_-]{11}$/.test(s)) return s
+  const patterns = [
+    /[?&]v=([a-zA-Z0-9_-]{11})/,
+    /youtu\.be\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ]
+  for (const p of patterns) {
+    const m = s.match(p)
+    if (m) return m[1]
+  }
+  return null
+}


### PR DESCRIPTION
Fecha o épico do Boletim Informativo: editor → publicação → página pública. Também fecha os itens adiados da **US-17** (CA-04 picker no editor, CA-05 bloqueio de imagem em uso).

## O que entrega
- **US-16 — Editor de blocos** (`/painel/boletins`, perm `boletim:write`): conteúdo em **linhas → colunas (1-4) → blocos** (JSONB). Blocos: Título, Texto rico (TipTap: negrito/itálico/listas/link + seletor Parágrafo/Título 1/2/3), Imagem, Galeria, Vídeo (YouTube). **Drag-and-drop** entre colunas/linhas (dnd-kit) + fallback ◀▶. Metadados (resumo, capa sugerida). Pré-visualização em nova aba.
- **US-17 (CA-04/05)** — `MediaPicker` com abas **Biblioteca/Enviar** (upload no modal); **usage checker** bloqueia excluir imagem em uso por boletim (capa ou bloco).
- **US-18 — Publicação** (perm `boletim:publish`): slug do título (transliteração, único com sufixo, imutável após publicar), publicar/despublicar, `published_at`, bloqueio de publicação incompleta.
- **US-19 — Página pública** `/boletins/:slug`: renderer compartilhado on-brand (full width, fundo padronizado, faixa azul+vermelha nos títulos), dentro do layout do site (header+footer), 404 para rascunho. **Open Graph server-side** (produção) via `PUBLIC_BASE_URL`. Copiar link + compartilhar no WhatsApp.

## Arquitetura
- Backend em camadas: `server/modules/boletins/` (repository/service/controller/routes + slug + usage checker), wired no `container.ts`. Migration `005_boletins.sql`. Permissão `boletim:publish` nova no catálogo.
- Frontend: `BulletinRenderer` compartilhado entre página pública e preview; extensões TipTap em módulo único (editor↔renderer não divergem). Deps novas: `@tiptap/*` (v2), `@dnd-kit/*`.

## Verificação
- `npm run build` (server tsc) e `tsc -p tsconfig.json` (frontend) verdes.
- Validação manual no browser (Playwright): criar/editar/colunas/DnD/upload/publicar/preview/404, mobile sem overflow.
- Spec: `docs/superpowers/specs/2026-06-16-boletim-editor-publicacao-design.md` · Plano: `docs/superpowers/plans/2026-06-16-boletim.md`.

## Notas
- OG só injeta em produção (Express serve `dist/index.html`); em dev o Vite serve o HTML. Configurar `PUBLIC_BASE_URL` no deploy.
- Projeto sem suíte de testes (convenção) — validação manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)