### PR TITLE
Sermões: usar YouTube Data API v3 (corrige feed bloqueado em prod)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ SMTP_USER=
 SMTP_PASS=
 PORT=3001
 
+# --- YouTube (sermões) ---
+# OBRIGATÓRIO em produção: o feed XML público do YouTube responde 404 para IPs de
+# datacenter/VPS, então sem chave os sermões ficam vazios. Crie uma chave da
+# "YouTube Data API v3" no Google Cloud e cole aqui. Em dev (IP residencial) é opcional.
+YOUTUBE_API_KEY=
+
 # --- Banco de dados (Postgres) ---
 # Em produção, deploy.sh gera POSTGRES_PASSWORD automaticamente.
 # O host do banco é "db" (nome do serviço no docker-compose).

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,6 +64,9 @@ if [ ! -f "$ENV_FILE" ]; then
   read -rp "URL pública do site (para o preview do boletim no WhatsApp/Open Graph) [https://www.adventistastucuruvi.com.br]: " public_base_url
   public_base_url="${public_base_url:-https://www.adventistastucuruvi.com.br}"
 
+  echo "Chave da YouTube Data API v3 (para os sermões; o feed público falha em IP de VPS)."
+  read -rp "YOUTUBE_API_KEY (deixe em branco para configurar depois): " youtube_api_key
+
   echo ""
   echo "--- Banco de dados (Postgres) ---"
   read -rp "Usuário do Postgres [iasd]: " pg_user
@@ -98,6 +101,9 @@ PORT=$app_port
 # --- App / Open Graph ---
 # URL pública absoluta do site, usada nas meta tags do boletim (og:url/og:image).
 PUBLIC_BASE_URL=$public_base_url
+
+# --- YouTube (sermões) — chave da YouTube Data API v3 (feed público falha em IP de VPS) ---
+YOUTUBE_API_KEY=$youtube_api_key
 
 # --- Banco de dados (Postgres) ---
 POSTGRES_USER=$pg_user

--- a/server/lib/youtube.ts
+++ b/server/lib/youtube.ts
@@ -21,34 +21,79 @@ function cleanTitle(t: string): string {
   return t.replace(/\p{Extended_Pictographic}/gu, '').replace(/\s+/g, ' ').trim()
 }
 
+/**
+ * Via oficial: YouTube Data API v3 (playlistItems.list). Funciona de qualquer IP, inclusive
+ * datacenter/VPS. Exige YOUTUBE_API_KEY. maxResults vai até 50 por chamada.
+ */
+async function fetchViaDataApi(playlistId: string, count: number, apiKey: string): Promise<YouTubeVideo[]> {
+  const max = Math.min(Math.max(count, 1), 50)
+  const url =
+    `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=${max}` +
+    `&playlistId=${encodeURIComponent(playlistId)}&key=${encodeURIComponent(apiKey)}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    console.warn(`[youtube] Data API ${res.status} para playlist ${playlistId}`)
+    return []
+  }
+  const body = (await res.json()) as {
+    items?: { snippet?: { title?: string; resourceId?: { videoId?: string } } }[]
+  }
+  const videos: YouTubeVideo[] = []
+  for (const item of body.items ?? []) {
+    const id = item.snippet?.resourceId?.videoId
+    const title = item.snippet?.title
+    // Ignora itens privados/removidos (sem título útil).
+    if (id && title && title !== 'Private video' && title !== 'Deleted video') {
+      videos.push({ videoId: id, title: cleanTitle(title) })
+    }
+  }
+  return videos
+}
+
+/**
+ * Fallback sem chave: feed XML público. ATENÇÃO — o YouTube responde 404 para IPs de
+ * datacenter/VPS, então em produção isso retorna vazio; serve sobretudo para o dev local.
+ */
+async function fetchViaFeed(playlistId: string): Promise<YouTubeVideo[]> {
+  const res = await fetch(`https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`)
+  if (!res.ok) {
+    console.warn(
+      `[youtube] feed XML ${res.status} para playlist ${playlistId} ` +
+        `(IPs de datacenter recebem 404 — configure YOUTUBE_API_KEY em produção).`,
+    )
+    return []
+  }
+  const xml = await res.text()
+  const videos: YouTubeVideo[] = []
+  const entryRe = /<entry>([\s\S]*?)<\/entry>/g
+  let m: RegExpExecArray | null
+  while ((m = entryRe.exec(xml)) !== null) {
+    const entry = m[1]
+    const id = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1]
+    const title = entry.match(/<title>([^<]*)<\/title>/)?.[1]
+    if (id && title) videos.push({ videoId: id, title: cleanTitle(decodeHtml(title)) })
+  }
+  return videos
+}
+
 export async function fetchYouTubePlaylist(playlistId: string, count: number): Promise<YouTubeVideo[]> {
   const now = Date.now()
   const cached = cache.get(playlistId)
-
   if (cached && now < cached.expiresAt) {
     return cached.data.slice(0, count)
   }
 
   try {
-    const res = await fetch(`https://www.youtube.com/feeds/videos.xml?playlist_id=${playlistId}`)
-    if (!res.ok) return []
+    const apiKey = process.env.YOUTUBE_API_KEY
+    const videos = apiKey
+      ? await fetchViaDataApi(playlistId, count, apiKey)
+      : await fetchViaFeed(playlistId)
 
-    const xml = await res.text()
-    const videos: YouTubeVideo[] = []
-    const entryRe = /<entry>([\s\S]*?)<\/entry>/g
-    let m: RegExpExecArray | null
-    while ((m = entryRe.exec(xml)) !== null) {
-      const entry = m[1]
-      const id = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1]
-      const title = entry.match(/<title>([^<]*)<\/title>/)?.[1]
-      if (id && title) {
-        videos.push({ videoId: id, title: cleanTitle(decodeHtml(title)) })
-      }
-    }
-
-    cache.set(playlistId, { data: videos, expiresAt: now + CACHE_TTL_MS })
+    // Só cacheia quando obteve algo, para não "fixar" vazio numa falha transitória.
+    if (videos.length) cache.set(playlistId, { data: videos, expiresAt: now + CACHE_TTL_MS })
     return videos.slice(0, count)
-  } catch {
+  } catch (err) {
+    console.warn('[youtube] falha ao buscar playlist:', err instanceof Error ? err.message : err)
     return []
   }
 }


### PR DESCRIPTION
## Problema
Em produção os sermões não carregam. O `server/lib/youtube.ts` usa o feed XML público (`feeds/videos.xml`), que o YouTube **responde 404 para IPs de datacenter/VPS** (confirmado: até um canal famoso dá 404 a partir de IP de datacenter). No dev (IP residencial) funciona; no VPS (Contabo) não → a rota devolve `[]` silenciosamente.

## Mudança
- `fetchYouTubePlaylist` passa a usar a **YouTube Data API v3** (`playlistItems.list`) quando `YOUTUBE_API_KEY` está definido — funciona de qualquer IP. Sem a chave, faz **fallback** para o feed XML (suficiente em dev).
- Loga as falhas (`[youtube] ...`) em vez de engolir; não cacheia resultado vazio.
- `.env.example` e `deploy.sh` documentam/geram a env `YOUTUBE_API_KEY`.

## Passo manual antes do merge/deploy
1. Criar a chave: Google Cloud → ativar **YouTube Data API v3** → **Criar credenciais → Chave de API** (grátis, sem faturamento; cota 10k/dia, usamos ~24/dia com cache de 1h).
2. No servidor: `echo 'YOUTUBE_API_KEY=...' >> .env.local`.
3. Merge desta branch + `./update.sh`.
4. Validar: `curl -s http://localhost:3001/api/youtube/cultos | head -c 200` deve listar vídeos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)