### PR TITLE
fix: páginas internas — grid, sermões (12 últimos + botão), cache YouTube e header

### DIFF
--- a/server/lib/youtube.ts
+++ b/server/lib/youtube.ts
@@ -4,6 +4,10 @@ export interface YouTubeVideo {
 }
 
 const CACHE_TTL_MS = 3600_000
+// Sempre busca o máximo da API (50) para o cache, independente do `count` pedido,
+// e fatia por requisição. Sem isso, o primeiro chamador (ex.: home com count=4)
+// fixaria o cache em 4 itens e /sermoes (count=12) só veria 4.
+const CACHE_FETCH_COUNT = 50
 const cache = new Map<string, { data: YouTubeVideo[]; expiresAt: number }>()
 
 function decodeHtml(s: string): string {
@@ -86,7 +90,7 @@ export async function fetchYouTubePlaylist(playlistId: string, count: number): P
   try {
     const apiKey = process.env.YOUTUBE_API_KEY
     const videos = apiKey
-      ? await fetchViaDataApi(playlistId, count, apiKey)
+      ? await fetchViaDataApi(playlistId, CACHE_FETCH_COUNT, apiKey)
       : await fetchViaFeed(playlistId)
 
     // Só cacheia quando obteve algo, para não "fixar" vazio numa falha transitória.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Routes, Route, Outlet } from 'react-router-dom'
+import { Routes, Route, Outlet, useLocation } from 'react-router-dom'
 import AOS from 'aos'
 import 'aos/dist/aos.css'
 
@@ -30,9 +30,15 @@ import { ProtectedRoute } from './auth/ProtectedRoute'
 import { RequirePermission } from './auth/RequirePermission'
 
 function PublicLayout() {
+  const { pathname } = useLocation()
+  // Páginas internas (sem hero) ganham um bloco azul sólido atrás do header fixo.
+  // Como está no fluxo normal, ele sobe junto ao rolar — então no topo o header
+  // semitransparente fica sobre azul sólido e, ao rolar, vira o glass sobre o conteúdo.
+  const isHome = pathname === '/'
   return (
     <>
       <Header />
+      {!isHome && <div className="h-20 bg-iasd-dark" aria-hidden />}
       <Outlet />
       <Footer />
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function PublicLayout() {
   return (
     <>
       <Header />
-      {!isHome && <div className="h-20 bg-iasd-dark" aria-hidden />}
+      {!isHome && <div className="h-16 bg-iasd-dark" aria-hidden />}
       <Outlet />
       <Footer />
     </>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,14 +49,14 @@ export default function Header() {
                     e.preventDefault()
                     handleClick(link.href)
                   }}
-                  className="text-sm font-medium text-gray-300 transition-colors hover:text-white"
+                  className="text-sm font-medium text-white transition-colors hover:text-gray-300"
                 >
                   {link.label}
                 </a>
               ) : (
                 <Link
                   to={link.href}
-                  className="text-sm font-medium text-gray-300 transition-colors hover:text-white"
+                  className="text-sm font-medium text-white transition-colors hover:text-gray-300"
                 >
                   {link.label}
                 </Link>
@@ -97,7 +97,7 @@ export default function Header() {
                     e.preventDefault()
                     handleClick(link.href)
                   }}
-                  className="block py-3 text-base font-medium text-gray-200 hover:text-white"
+                  className="block py-3 text-base font-medium text-white hover:text-gray-300"
                 >
                   {link.label}
                 </a>
@@ -105,7 +105,7 @@ export default function Header() {
                 <Link
                   to={link.href}
                   tabIndex={menuOpen ? 0 : -1}
-                  className="block py-3 text-base font-medium text-gray-200 hover:text-white"
+                  className="block py-3 text-base font-medium text-white hover:text-gray-300"
                   onClick={() => setMenuOpen(false)}
                 >
                   {link.label}

--- a/src/pages/BoletimPublico.tsx
+++ b/src/pages/BoletimPublico.tsx
@@ -65,7 +65,7 @@ export default function BoletimPublico() {
       : window.location.href
 
   return (
-    <main className="boletim-bg min-h-screen px-4 pb-20 pt-24 md:pt-28">
+    <main className="boletim-bg min-h-screen px-4 pb-20 pt-8 md:pt-10">
       <article className="mx-auto max-w-5xl">
         {boletim.coverMediaId && (
           <img

--- a/src/pages/Galeria.tsx
+++ b/src/pages/Galeria.tsx
@@ -21,7 +21,7 @@ export default function Galeria() {
   }, [])
 
   return (
-    <main className="bg-iasd-light pt-24 pb-20">
+    <main className="bg-iasd-light pt-8 pb-20">
       <div className="container mx-auto max-w-5xl px-4">
         <SectionTitle title="Galeria" subtitle="Nossos momentos" />
         {loading ? (

--- a/src/pages/Sermoes.tsx
+++ b/src/pages/Sermoes.tsx
@@ -36,7 +36,7 @@ export default function Sermoes() {
         )}
         <div className="mt-10 text-center">
           <a
-            href="https://www.youtube.com/@IASDTucuruviOficial/streams"
+            href="https://www.youtube.com/playlist?list=PLwnLJcWxPcgSDNzfxjlhRC-3QC-3h2Atb"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block rounded-full border-2 border-iasd-dark px-8 py-3 font-heading font-bold text-iasd-dark transition-colors hover:bg-iasd-dark hover:text-white"

--- a/src/pages/Sermoes.tsx
+++ b/src/pages/Sermoes.tsx
@@ -12,7 +12,7 @@ export default function Sermoes() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetch('/api/youtube/cultos?count=15')
+    fetch('/api/youtube/cultos?count=12')
       .then((res) => res.json())
       .then((data) => setVideos(data))
       .catch(() => setVideos([]))
@@ -21,12 +21,12 @@ export default function Sermoes() {
 
   return (
     <main className="bg-white pt-24 pb-20">
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto max-w-5xl px-4">
         <SectionTitle title="Sermões" subtitle="Todos os cultos de sábado" />
         {loading ? (
           <p className="text-center text-gray-500">Carregando sermões...</p>
         ) : videos.length > 0 ? (
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {videos.map((v, i) => (
               <VideoCard key={v.videoId} videoId={v.videoId} title={v.title} delay={i * 50} />
             ))}
@@ -34,6 +34,16 @@ export default function Sermoes() {
         ) : (
           <p className="text-center text-gray-500">Não foi possível carregar os sermões.</p>
         )}
+        <div className="mt-10 text-center">
+          <a
+            href="https://www.youtube.com/@IASDTucuruviOficial/streams"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-full border-2 border-iasd-dark px-8 py-3 font-heading font-bold text-iasd-dark transition-colors hover:bg-iasd-dark hover:text-white"
+          >
+            Ao Vivo no canal
+          </a>
+        </div>
       </div>
     </main>
   )

--- a/src/pages/Sermoes.tsx
+++ b/src/pages/Sermoes.tsx
@@ -41,7 +41,7 @@ export default function Sermoes() {
             rel="noopener noreferrer"
             className="inline-block rounded-full border-2 border-iasd-dark px-8 py-3 font-heading font-bold text-iasd-dark transition-colors hover:bg-iasd-dark hover:text-white"
           >
-            Ao Vivo no canal
+            Sermões no YouTube
           </a>
         </div>
       </div>

--- a/src/pages/Sermoes.tsx
+++ b/src/pages/Sermoes.tsx
@@ -20,7 +20,7 @@ export default function Sermoes() {
   }, [])
 
   return (
-    <main className="bg-white pt-24 pb-20">
+    <main className="bg-white pt-8 pb-20">
       <div className="container mx-auto max-w-5xl px-4">
         <SectionTitle title="Sermões" subtitle="Todos os cultos de sábado" />
         {loading ? (


### PR DESCRIPTION
## O que muda

### Página de Sermões (`src/pages/Sermoes.tsx`)
- **Respeita o grid do site** (`max-w-5xl`, mesmo padrão da Galeria/home); grid até 3 colunas.
- **Carrega os 12 últimos** cultos (`count=12`).
- **Botão "Sermões no YouTube"** apontando para a playlist de cultos (`PLwnLJcWxPcgSDNzfxjlhRC-3QC-3h2Atb`).

### Cache do YouTube (`server/lib/youtube.ts`) — corrige o "só 4 em produção"
O cache de 1h guardava a lista do tamanho que o primeiro chamador pedia. A home (`SermoesPreview`, `count=4`) esquentava o cache com 4 vídeos e `/sermoes` recebia `slice(0,12)` de 4 = 4. Agora busca sempre 50 (máx. da API) e fatia por requisição.

### Header / páginas internas
- **Faixa azul sólida atrás do header** (no `PublicLayout`, só fora da home), `h-16` = mesma altura do menu. Fica atrás do header fixo e sobe ao rolar. Offset das páginas ajustado (`pt-24` → `pt-8`).
- **Links do menu em branco (#fff)**, hover em cinza claro.

## Notas
- Galeria já respeitava `max-w-5xl` — sem alteração.
- Cache é em memória; reinicia limpo no deploy.
- Mostrar 12 depende de a playlist de cultos ter ≥12 vídeos.

## Teste
- `npm run build` ✅ (frontend + servidor)
- Validação manual no browser (convenção do projeto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)